### PR TITLE
ci: remove unnecessary steps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,19 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Node.js v18
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-          check-latest: true
-
-      - name: Setup Java v17
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'corretto'
-          java-version: 17
-          check-latest: true
-
       - name: Cache Gradle and wrapper
         uses: actions/cache@v3
         with:
@@ -32,10 +19,10 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
 
-      - name: Set env
+      - name: Set release version environment variable
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
-      - name: Clone TizenTube to assets
+      - name: Clone TizenTube assets
         working-directory: androidApp/app/src/main/assets
         run: git clone https://github.com/reisxd/TizenTube.git tizentube
 


### PR DESCRIPTION
- The removed steps are unnecessary because the runner has Node 18 and Java 17 preinstalled.
- Also, you may move files instead of cloning them.
- You may be able to use a wildcard for `files` in action `action-gh-release`: `*.apk`