### PR TITLE
Adds docker-compose to run node.js with TizenTube on raspberry pi

### DIFF
--- a/dockerpi_tizen/Dockerfile
+++ b/dockerpi_tizen/Dockerfile
@@ -1,0 +1,12 @@
+FROM arm32v7/node
+
+WORKDIR /app
+
+COPY requirements.txt ./
+COPY /TizenTube/ ./
+WORKDIR /app
+RUN npm i
+WORKDIR /app/mods
+RUN npm i
+RUN npm run build
+WORKDIR /app

--- a/dockerpi_tizen/docker-compose.yml
+++ b/dockerpi_tizen/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  power_tizen:
+    build: .
+    restart: always
+    image: nodetizen:v1
+    network_mode: "host"
+    command: node .
+


### PR DESCRIPTION
For ease of use (related to Issue Provide a docker image for the server)
Adds docker-compose configuration files to run node.js with TizenTube code (previously copied to TizenTube folder inside dockerpi) on raspberry pi