### PR TITLE
amend install instructions: Tizen Studio 5.5 macOS broken, device manager launch failure workaround, change TV dev IP to server's IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ TizenTube operates by initiating a debugger session upon launching the app on yo
 2. **Install Tizen Studio** by following [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/installing-tv-sdk.html).
      - Make sure to install the Tizen TV Extensions SDK. Although project's TV Extensions SDK version is 6.x.x, version 7.0.0 works too.
      - Also install the Samsung Certificate Extension
-         - Note: This extension's installation on Tizen Studio 5.5 with IDE installer for **macOS** is broken. This breaks proper certificate creation (step 6). Therefore, avoid this macOS Tizen Studio version or use Windows/Ubuntu version.
+         - Note: This extension's installation on Tizen Studio 5.5 with IDE installer for **macOS** is broken. This breaks proper certificate creation (step 4). Therefore, avoid this macOS Tizen Studio version or use Windows/Ubuntu version.
 3. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
      - If opening Device Manager fails, use the _Launch Remote Device Manager_ option ([see here](https://stackoverflow.com/questions/67401253/device-manager-for-tizen-wont-open-0xc000007b))
-5. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
-6. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
-7. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
-8. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
-9. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
+4. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
+5. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
+6. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
+7. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
+8. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
 
 After completing these steps, installing apps is complete! You should be able to see the apps on your TV. Now comes the easier part, installing the server or the debugger. You have two options to do this:
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ TizenTube operates by initiating a debugger session upon launching the app on yo
      - Make sure to install the Tizen TV Extensions SDK. Although project's TV Extensions SDK version is 6.x.x, version 7.0.0 works too.
      - Also install the Samsung Certificate Extension
          - Note: This extension's installation on Tizen Studio 5.5 with IDE installer for **macOS** is broken. This breaks proper certificate creation (step 6). Therefore, avoid this macOS Tizen Studio version or use Windows/Ubuntu version.
-5. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
-6. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
-7. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
-8. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
-9. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
-10. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
+3. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
+4. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
+5. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
+6. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
+7. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
+8. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
 
 After completing these steps, installing apps is complete! You should be able to see the apps on your TV. Now comes the easier part, installing the server or the debugger. You have two options to do this:
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Once the server is up and running, you can access the Launcher app from your TVâ
 ### Option 2: Use The Android App
 
 1. First, change the Developer Mode's Host IP to your device's IP.
-2. Download the latest APK compatible with your device's architecture from [here](https://github.com/reisxd/TizenTube/releases/tag/v1.1.2) (if unsure, download armeabi-v7a).
+2. Download the latest APK compatible with your device's architecture from [here](https://github.com/reisxd/TizenTube/releases/latest) (if unsure, download armeabi-v7a).
 3. Install it.
 4. After opening the app, change the configuration to suit your needs. Ensure that you set the `appID` to `Ad6NutHP8l.TizenTube` if it isn't already set. Change the IP to match that of your TV.
 5. Change the development IP address on the TV (previously set in step 1 of Installation Steps) to that of this Android device which you'll run the server on.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ TizenTube operates by initiating a debugger session upon launching the app on yo
 ## Installation Steps
 
 1. **Enable Developer Mode** on your TV by following [this link](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html).
-2. **Install Tizen Studio** by following [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/installing-tv-sdk.html). Make sure to install the Tizen SDK version 6.x.x, which is the project’s SDK version..
-3. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
-4. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
-5. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
-6. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
-7. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
-8. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
+2. **Install Tizen Studio** by following [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/installing-tv-sdk.html).
+     - Make sure to install the Tizen TV Extensions SDK. Although project's TV Extensions SDK version is 6.x.x, version 7.0.0 works too.
+     - Also install the Samsung Certificate Extension
+         - Note: This extension's installation on Tizen Studio 5.5 with IDE installer for **macOS** is broken. This breaks proper certificate creation (step 6). Therefore, avoid this macOS Tizen Studio version or use Windows/Ubuntu version.
+5. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
+6. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
+7. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
+8. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
+9. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
+10. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
 
 After completing these steps, installing apps is complete! You should be able to see the apps on your TV. Now comes the easier part, installing the server or the debugger. You have two options to do this:
 
@@ -38,7 +41,8 @@ After completing these steps, installing apps is complete! You should be able to
 6. Navigate back to the main folder of the repository by running `cd ..`.
 7. Open `config.json` in your favorite text editor. Change `tvIP` to the IP of your TV. Make sure to leave the `appID` as it is (`Ad6NutHP8l.TizenTube`). Change `isTizen3` to true if your TV runs on Tizen 3.
 8. Ensure that SDB is not running by going to Tizen's device manager and disconnecting your TV.
-9. Start the node debugger/server using `node .`.
+9. Change the development IP address on the TV (previously set in step 1 of Installation Steps above), to the IP of this PC that you'll run the node server on.
+10. Start the node debugger/server using `node .`.
 
 Once the server is up and running, you can access the Launcher app from your TV’s app menu. Please note that the TizenTube app will still display ads if it is run on its own. To remove ads, make sure to launch TizenTube through the Launcher app, which is connected to the server.
 
@@ -48,8 +52,9 @@ Once the server is up and running, you can access the Launcher app from your TV�
 2. Download the latest APK compatible with your device's architecture from [here](https://github.com/reisxd/TizenTube/releases/tag/v1.1.2) (if unsure, download armeabi-v7a).
 3. Install it.
 4. After opening the app, change the configuration to suit your needs. Ensure that you set the `appID` to `Ad6NutHP8l.TizenTube` if it isn't already set. Change the IP to match that of your TV.
-5. Press 'Run Server'.
-6. Press 'Launch' whenever you want to launch TizenTube.
-7. Please note that if the app crashes, you may have made an error, such as setting an incorrect IP or failing to change the Developer Mode's Host IP.
+5. Change the development IP address on the TV (previously set in step 1 of Installation Steps) to that of this Android device which you'll run the server on.
+6. Press 'Run Server'.
+7. Press 'Launch' whenever you want to launch TizenTube.
+8. Please note that if the app crashes, you may have made an error, such as setting an incorrect IP or failing to change the Developer Mode's Host IP.
 
 And now you can launch TizenTube from your Android device!

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ TizenTube operates by initiating a debugger session upon launching the app on yo
      - Also install the Samsung Certificate Extension
          - Note: This extension's installation on Tizen Studio 5.5 with IDE installer for **macOS** is broken. This breaks proper certificate creation (step 6). Therefore, avoid this macOS Tizen Studio version or use Windows/Ubuntu version.
 3. **Connect to your TV** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html#:~:text=Connect%20the%20TV%20to%20the%20SDK%3A).
-4. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
-5. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
-6. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
-7. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
-8. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
+     - If opening Device Manager fails, use the _Launch Remote Device Manager_ option ([see here](https://stackoverflow.com/questions/67401253/device-manager-for-tizen-wont-open-0xc000007b))
+5. **Create a Samsung certificate** using [this guide](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html).
+6. **Clone/download the repository** and open the `apps` folder of the repository in Tizen Studio by restarting Tizen Studio and changing the workspace.
+7. In the `index.html` file of the Launcher app, change the `IP` variable to the IP of where your debugger will be installed. This could also be the IP of your android device if you plan on using that instead.
+8. Ensure that your TV is selected at the top of Tizen Studio (the dropdown menu).
+9. Right-click the `TizenTube` app and run it as a Tizen web application. Once that is done, do the same for the `Launcher` app.
 
 After completing these steps, installing apps is complete! You should be able to see the apps on your TV. Now comes the easier part, installing the server or the debugger. You have two options to do this:
 


### PR DESCRIPTION
Recently setup TizenTube; got it working (love it).
However, I did encounter some install obstacles that I thought others might run into as well, hence this PR for the README.

- To get the certificate created properly (with the DUID screen), the Samsung Certificate Extension needs to be installed. However, on macOS version 5.5 of Tizen Studio, the install process for that extension from the Package Manager is broken. Some warning window comes up, with white text atop a white background (lol). So cannot even tell why it fails but it just does. This, in turn, makes the running of the `TizenTube` and `Launcher` apps from Tizen Studio fail, due to an invalid certificate. I had to switch over to the Windows version of Tizen Studio to get everything working, no issues on that.
   
- To connect to the TV, Device Manager in Tizen Studio failed to open on both macOS and Windows. I had to click on the device selector and then _Launch Remote Device Manager_ to get to the relevant window.

- After installing the `TizenTube` and `Launcher` apps from Tizen Studio, the TV development IP address must be changed to that of the server's (node server on PC or the Android app), which you setup in the next set of instructions. If this is not done, the `Launcher` app just times out. I think this is a pretty crucial missing step.

- Android app link in step 2 of instructions is for version 1.1.2, changed to latest release.

Again, absolutely love the app, works flawlessly. Thank you @reisxd for this wonderful work.
Hopefully these install instruction amendments make the process a bit smoother for future users.