### PR TITLE
Change checkable Settings wording

### DIFF
--- a/mods/modernUI.js
+++ b/mods/modernUI.js
@@ -14,29 +14,29 @@ export default function modernUI(update, parameters) {
             value: 'enableSponsorBlock'
         },
         {
-            name: 'Skipping Sponsor Segments',
+            name: 'Skip Sponsor Segments',
             icon: 'MONEY_HEART',
             value: 'enableSponsorBlockSponsor'
         },
         {
-            name: 'Skipping Intro Segments',
+            name: 'Skip Intro Segments',
             icon: 'PLAY_CIRCLE',
             value: 'enableSponsorBlockIntro'
         },
         {
-            name: 'Skipping Outro Segments',
+            name: 'Skip Outro Segments',
             value: 'enableSponsorBlockOutro'
         },
         {
-            name: 'Skipping Interaction Reminder Segments',
+            name: 'Skip Interaction Reminder Segments',
             value: 'enableSponsorBlockInteraction'
         },
         {
-            name: 'Skipping Self-Promotion Segments',
+            name: 'Skip Self-Promotion Segments',
             value: 'enableSponsorBlockSelfPromo'
         },
         {
-            name: 'Skipping Off-Topic Music Segments',
+            name: 'Skip Off-Topic Music Segments',
             value: 'enableSponsorBlockMusicOfftopic'
         },
         {
@@ -50,7 +50,7 @@ export default function modernUI(update, parameters) {
             value: 'enableDeArrowThumbnails'
         },
         {
-            name: 'Fixed UI',
+            name: 'Fix UI',
             icon: 'STAR',
             value: 'enableFixedUI'
         }
@@ -63,7 +63,7 @@ export default function modernUI(update, parameters) {
         const currentVal = configRead(setting.value);
         buttons.push(
             buttonItem(
-                { title: `${currentVal ? 'Disable' : 'Enable'} ${setting.name}`, subtitle: setting.subtitle },
+                { title: setting.name, subtitle: setting.subtitle },
                 { icon: setting.icon ? setting.icon : 'CHEVRON_DOWN', secondaryIcon: currentVal ? 'CHECK_BOX' : 'CHECK_BOX_OUTLINE_BLANK' },
                 [
                     {


### PR DESCRIPTION
Now that the settings UI is much fancier, let's make the wording of settings a little more consistent and readable.

Instead of displaying the current state in **both** checkbox and text, just display the text stating _what_ will be enabled by checking the box. This also updates some labels to better suit the new format.

Alternatively, we could change it to always display the word "Enable" (though I feel it'd be an inefficient use of space).

> Write check-box labels so that they describe the checked (selected) state of the check box
Source: https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb246416(v=vs.85)

> The checkbox text describes the positive action (as in “true” or “yes”)
Source: https://experience.sap.com/fiori-design-web/checkbox/

For reference, the "Stable volume" and "Stats for nerds" toggles in YouTube TV do not use Enable/Disable text.