### PR TITLE
Fix Black Area When Show Timeline Video

### DIFF
--- a/mods/ui/ui.css
+++ b/mods/ui/ui.css
@@ -99,3 +99,8 @@
 .ytLrProgressBarPlayed {
   z-index: 1 !important;
 }
+
+/* Remove Background Black Arrea When Move Down In Video */
+.ytLrWatchDefaultControlsBackground {
+  background-color: transparent !important;
+}


### PR DESCRIPTION
I want make transparent from this: https://media.discordapp.net/attachments/1180836790781878352/1410916387484074037/image.png?ex=68b2c1c8&is=68b17048&hm=86057aed8e0573985dd5b4ad7acb6fe470dbe86c0697a21cb0ff937f3730bfd4&=&width=1068&height=492
To:
https://media.discordapp.net/attachments/1180836790781878352/1410916469751152680/image.png?ex=68b2c1db&is=68b1705b&hm=751e6fbf2426137b91359d6d7b709d16393cef8b7c19cd241433730727e2ae66&=&width=1060&height=492