### PR TITLE
sponsorblock: migrate to official API endpoint

### DIFF
--- a/mods/sponsorblock.js
+++ b/mods/sponsorblock.js
@@ -46,7 +46,7 @@ const barTypes = {
   }
 };
 
-const sponsorblockAPI = 'https://sponsorblock.inf.re/api';
+const sponsorblockAPI = 'https://sponsor.ajay.app/api';
 
 class SponsorBlockHandler {
   video = null;


### PR DESCRIPTION
Hey.

This project has inherited a quick and dirty hack for missing recent Let's Encrypt intermediate CA certificates we did back in early [youtube-webos](https://github.com/webosbrew/youtube-webos) days. This involved proxying over sponsorblock API via my private infrastructure, exposed behind ZeroSSL-issued certificate (which was trusted by all webOS versions at the time). Turns out most of the traffic now is actually coming from Cobalt and Tizen... :D

Not sure if this was ever needed on Tizen (and especially now on Cobalt/Android).
Regardless - looks like `sponsor.ajay.app` is now hosted behind Google Trust Services CA/GTS Root R4 certificate, which should be equally respected. Alternatively seems like `api.sponsor.ajay.app` is another alternative endpoint hosted behind ZeroSSL-issued certificate, but I'm not sure if this is deprecated or not, since I couldn't quickly find any mentions of this domain in their API docs. I guess doing a fallback from one to the other on error could be an option.

This is approx 4-12mbps of constant traffic on my part - manageable, but I may be sunsetting this VM at some point in near future, and I'd love to reduce dependency of others on my infra.
<img width="1363" height="360" alt="image" src="https://github.com/user-attachments/assets/82e600ed-027a-4e36-9ba7-c018ba8cdf4e" />
<img width="2331" height="688" alt="image" src="https://github.com/user-attachments/assets/945c55ed-1769-4a85-82eb-442336a98664" />

No device on hand to test this, sorry.