### PR TITLE
Fix: Updater not showing modal.

### DIFF
--- a/mods/features/updater.js
+++ b/mods/features/updater.js
@@ -71,7 +71,6 @@ if (window.h5vcc && window.h5vcc.tizentube) {
                                 ]
                             )
                         ]),
-                        0,
                         'tt-update-modal'
                     )
                 } else {


### PR DESCRIPTION
Fixed update check not showing modal because of passing incorrect arguments to `showModal` method.