### PR TITLE
fix: prevent TypeError crashes in JSON.parse override causing tabs not to load

### DIFF
--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -68,7 +68,7 @@ JSON.parse = function () {
         );
 
       for (const shelve of r.contents.tvBrowseRenderer.content.tvSurfaceContentRenderer.content.sectionListRenderer.contents) {
-        if (shelve.shelfRenderer) {
+        if (shelve.shelfRenderer && shelve.shelfRenderer.content?.horizontalListRenderer?.items) {
           shelve.shelfRenderer.content.horizontalListRenderer.items =
             shelve.shelfRenderer.content.horizontalListRenderer.items.filter(
               (item) => !item.adSlotRenderer
@@ -123,6 +123,7 @@ JSON.parse = function () {
   if (r?.contents?.tvBrowseRenderer?.content?.tvSecondaryNavRenderer?.sections) {
     for (let i = 0; i < r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections.length; i++) {
       const section = r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections[i].tvSecondaryNavSectionRenderer;
+      if (!section || !section.tabs) continue;
 
       if (configRead('sortSubscriptionsByAlphabet')) {
         section.tabs.sort((a, b) => {
@@ -265,6 +266,7 @@ for (const key in window._yttv) {
 function processShelves(shelves, shouldAddPreviews = true) {
   for (const shelve of shelves) {
     if (shelve.shelfRenderer) {
+      if (!shelve.shelfRenderer.content?.horizontalListRenderer?.items) continue;
       deArrowify(shelve.shelfRenderer.content.horizontalListRenderer.items);
       hqify(shelve.shelfRenderer.content.horizontalListRenderer.items);
       addLongPress(shelve.shelfRenderer.content.horizontalListRenderer.items);
@@ -346,6 +348,7 @@ function hqify(items) {
     if (item.tileRenderer.style !== 'TILE_STYLE_YTLR_DEFAULT') continue;
     if (configRead('enableHqThumbnails')) {
       if (!item.tileRenderer.onSelectCommand?.watchEndpoint?.videoId) continue;
+      if (!item.tileRenderer.header?.tileHeaderRenderer?.thumbnail?.thumbnails?.[0]?.url) continue;
       const videoID = item.tileRenderer.onSelectCommand.watchEndpoint.videoId;
       const queryArgs = item.tileRenderer.header.tileHeaderRenderer.thumbnail.thumbnails[0].url.split('?')[1];
       item.tileRenderer.header.tileHeaderRenderer.thumbnail.thumbnails = [
@@ -377,7 +380,11 @@ function addLongPress(items) {
     }
     if (!configRead('enableLongPress')) continue;
     if (!item.tileRenderer?.metadata?.tileMetadataRenderer) continue;
-    const subtitle = item.tileRenderer.metadata.tileMetadataRenderer.lines[0].lineRenderer.items[0].lineItemRenderer.text;
+    if (!item.tileRenderer?.header?.tileHeaderRenderer?.thumbnail?.thumbnails) continue;
+    if (!item.tileRenderer.onSelectCommand?.watchEndpoint) continue;
+    const subtitleNode = item.tileRenderer.metadata.tileMetadataRenderer.lines?.[0]?.lineRenderer?.items?.[0]?.lineItemRenderer?.text;
+    if (!subtitleNode) continue;
+    const subtitle = subtitleNode;
     const data = longPressData({
       videoId: item.tileRenderer.contentId,
       thumbnails: item.tileRenderer.header.tileHeaderRenderer.thumbnail.thumbnails,
@@ -396,8 +403,9 @@ function hideVideo(items) {
     const progressBar = item.tileRenderer.header?.tileHeaderRenderer?.thumbnailOverlays?.find(overlay => overlay.thumbnailOverlayResumePlaybackRenderer)?.thumbnailOverlayResumePlaybackRenderer;
     if (!progressBar) return true;
     const pages = configRead('hideWatchedVideosPages');
+    if (!pages.length) return true;
     const hash = location.hash.substring(1);
-    const pageName = hash === '/' ? 'home' : hash.startsWith('/search') ? 'search' : hash.split('?')[1].split('&')[0].split('=')[1].replace('FE', '').replace('topics_', '');
+    const pageName = hash === '/' ? 'home' : hash.startsWith('/search') ? 'search' : hash.split('?')[1]?.split('&')[0]?.split('=')[1]?.replace('FE', '')?.replace('topics_', '') ?? '';
     if (!pages.includes(pageName)) return true;
 
     const percentWatched = (progressBar.percentDurationWatched || 0);

--- a/mods/ui/customGuideAction.js
+++ b/mods/ui/customGuideAction.js
@@ -7,11 +7,13 @@ JSON.parse = function () {
 
     const disabledSidebarContents = configRead('disabledSidebarContents');
     if (r.items && Array.isArray(r.items) && r.items[0].guideSectionRenderer) {
+        if (!disabledSidebarContents.length) return r;
         for (let i = 0; i < r.items.length; i++) {
             const section = r.items[i].guideSectionRenderer;
             for (let j = 0; j < section.items.length; j++) {
                 const item = section.items[j].guideEntryRenderer;
                 if (!item) continue;
+                if (!item.icon) continue;
                 if (disabledSidebarContents.includes(item.icon.iconType)) {
                     section.items.splice(j, 1);
                     j--;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foxreis/tizentube",
   "appName": "TizenTube",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "description": "TizenTube is an ad-free and sponsor-free solution for your favourite streaming website on your Tizen (Samsung) TVs.",
   "packageType": "mods",
   "websiteURL": "https://youtube.com/tv?additionalDataUrl=http%3A%2F%2Flocalhost%3A8085%2Fdial%2Fapps%2FYouTube",


### PR DESCRIPTION
## Problem

Multiple tabs (Library, Subscriptions, and other browse tabs) show an infinite spinner with no error. The root cause is unguarded property access inside the global `JSON.parse` override in `adblock.js` and `customGuideAction.js`; any `TypeError` thrown there causes the app to silently discard the entire API response. This is also why disabling Ad Block in settings has no effect.

## Solution

Added null guards for the cases that were crashing:

- **Library shelves**: use `gridRenderer`, not `horizontalListRenderer`; skipped in `processShelves` and the ad-removal loop when the expected structure is absent
- **`tvSecondaryNavRenderer` sections**: skip entries that are not `tvSecondaryNavSectionRenderer`
- **`hqify`**: skip tiles with no thumbnail URL
- **`addLongPress`**: skip tiles with no `watchEndpoint` or subtitle (playlists, channels)
- **`hideVideo`**: early return when `hideWatchedVideosPages` is empty; optional-chain `hash.split('?')[1]` (the Library hash `#/browse/FElibrary` has no `?`)
- **`customGuideAction`**: early return when no sidebar contents are disabled; skip guide entries with no `icon`