### PR TITLE
Fix page overlap

### DIFF
--- a/mods/ui/ui.css
+++ b/mods/ui/ui.css
@@ -158,5 +158,5 @@ div[idomkey="shadow"] {
 
 /* Narrow only the expanded guide variant to avoid overlapping page content. */
 ytlr-guide-response.RYo6Fb[aria-hidden="false"] .hsdF6b {
-  max-width: 17.75rem !important;
+  width: 17rem !important;
 }

--- a/mods/ui/ui.css
+++ b/mods/ui/ui.css
@@ -155,3 +155,8 @@ div[idomkey="shadow"] {
 .ytContribIconHost::before {
     font-family: "YouTube Icons Outlined";
 }
+
+/* Narrow only the expanded guide variant to avoid overlapping page content. */
+ytlr-guide-response.RYo6Fb[aria-hidden="false"] .hsdF6b {
+  max-width: 17.75rem !important;
+}


### PR DESCRIPTION
Hi,

this fixes on all pages the overlap of the extended sidebar:

before:
<img width="551" height="688" alt="image" src="https://github.com/user-attachments/assets/0ee71794-e138-4e37-9585-3dfef35e1bf0" />


after:
<img width="581" height="685" alt="image" src="https://github.com/user-attachments/assets/49babe6d-1f42-43b4-8eeb-4c66bff13326" />