### PR TITLE
Added Go to Channel button on Long Pressing Thumbnail

### DIFF
--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -378,6 +378,15 @@ function addLongPress(items) {
           }
         }
       }));
+      item.tileRenderer.onLongPressCommand.showMenuCommand.menu.menuRenderer.items.push(MenuServiceItemRenderer('Go to Channel', {
+        clickTrackingParams: null,
+        playlistEditEndpoint: {
+          customAction: {
+            action: 'GO_TO_CHANNEL',
+            parameters: { videoId: item.tileRenderer.contentId }
+          }
+        }
+      }));
       continue;
     }
     if (!configRead('enableLongPress')) continue;

--- a/mods/resolveCommand.js
+++ b/mods/resolveCommand.js
@@ -212,6 +212,9 @@ function customAction(action, parameters) {
             window.queuedVideos.videos.push(parameters);
             showToast('TizenTube', 'Video added to queue.');
             break;
+        case 'GO_TO_CHANNEL':
+            goToChannel(parameters);
+            break;
         case 'CLEAR_QUEUE':
             window.queuedVideos.videos = [];
             showToast('TizenTube', 'Video queue cleared.');
@@ -220,4 +223,32 @@ function customAction(action, parameters) {
             checkForUpdates(true);
             break;
     }
+}
+
+function goToChannel(parameters) {
+    const videoId = parameters && parameters.videoId;
+    if (!videoId) {
+        showToast('TizenTube', 'Could not determine video.');
+        return;
+    }
+    fetch('https://www.youtube.com/watch?v=' + encodeURIComponent(videoId) + '&hl=en', {
+        credentials: 'omit'
+    })
+        .then(function (res) { return res.text(); })
+        .then(function (html) {
+            const match = html.match(/"channelId":"(UC[A-Za-z0-9_-]{20,})"/);
+            if (!match) {
+                showToast('TizenTube', 'Could not find channel.');
+                return;
+            }
+            const channelId = match[1];
+            resolveCommand({
+                browseEndpoint: {
+                    browseId: channelId
+                }
+            });
+        })
+        .catch(function () {
+            showToast('TizenTube', 'Failed to load channel.');
+        });
 }

--- a/mods/ui/ytUI.js
+++ b/mods/ui/ytUI.js
@@ -235,6 +235,15 @@ function longPressData(data) {
                                 }
                             }
                         }),
+                        MenuServiceItemRenderer('Go to Channel', {
+                            clickTrackingParams: null,
+                            playlistEditEndpoint: {
+                                customAction: {
+                                    action: 'GO_TO_CHANNEL',
+                                    parameters: { videoId: data.videoId }
+                                }
+                            }
+                        }),
                     ],
                     trackingParams: null,
                     accessibility: {


### PR DESCRIPTION
What this adds:
Adds a "Go to Channel" option to the long press menu on video tiles, appearing right below the existing "Add to Queue" button.

How it works:
When selected, it fetches the video's watch page to resolve the channel ID, then navigates directly to the channel using the existing browseEndpoint resolver.

Files changed:
mods/features/adblock.js - adds the menu item for videos that already have a long press menu
mods/ui/ytUI.js - adds the menu item for newly built long press menus
mods/resolveCommand.js - handles the GO_TO_CHANNEL action and adds the goToChannel() function

Planned follow-up (if this gets accepted):
I'm also planning a follow-up PR that adds a settings entry letting users configure which 4 items appear in the long press menu. "Play" would stay fixed as the first item since it's the primary action, but the other 3 slots would be user-configurable from the full list of available options (Save to Watch Later, Save to Playlist, Add to Queue, Go to Channel, and any future additions). This keeps the menu visually consistent at 4 items while giving users flexibility — people who use the queue can keep it, people who don't can swap it out for Go to Channel or something else.