### PR TITLE
bug: Fixing search issue when using multiple words.

### DIFF
--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -97,9 +97,9 @@ JSON.parse = function () {
     );
   }
 
-  // Patch settings
-
-  if (r?.title?.runs) {
+  // Patch settings, only when we detect items related to settings
+  
+  if (isSettingsResponse(r)) {
     PatchSettings(r);
   }
 
@@ -262,6 +262,11 @@ for (const key in window._yttv) {
   }
 }
 
+function isSettingsResponse(r) {
+  return r?.title?.runs && Array.isArray(r.items) && r.items.some(
+    (item) => item.settingCategoryCollectionRenderer || item.settingActionRenderer
+  );
+}
 
 function processShelves(shelves, shouldAddPreviews = true) {
   for (const shelve of shelves) {


### PR DESCRIPTION
https://github.com/reisxd/TizenTube/issues/528

This is the issue which I opened recently where searches with multiple words were ending up with more search terms but not the video results.

It looks like the patchsettings currently triggers when have title.runs available is a loose condition as the multi word search also have title.runs and items, so the fix was to only trigger patch settings when we actually want it by looking at settingCategoryCollectionRenderer and settingActionRenderer 