### PR TITLE
Fix: serve the real youtube.com over CDP so playback works (fixes #555, #561)

### DIFF
--- a/standalone/index.html
+++ b/standalone/index.html
@@ -4,6 +4,34 @@
     <style>
         body {
             background-color: #0f0f0f;
+            color: #cfcfcf;
+            font-family: Arial, Helvetica, sans-serif;
+            margin: 0;
+        }
+
+        #boot {
+            padding: 48px 64px;
+        }
+
+        #boot h1 {
+            font-size: 34px;
+            font-weight: normal;
+            color: #ffffff;
+            margin: 0 0 18px 0;
+        }
+
+        #phase {
+            font-size: 24px;
+            color: #9ecbff;
+        }
+
+        #detail {
+            font-size: 15px;
+            line-height: 1.45;
+            color: #8a8a8a;
+            margin-top: 14px;
+            white-space: pre-wrap;
+            font-family: "Courier New", monospace;
         }
     </style>
     <script>
@@ -28,6 +56,124 @@
             tizen.tvinputdevice.registerKey(keys[i]);
         }
 
+        const PROXY_BASE = 'http://localhost:8099';
+        const PROXY_FALLBACK_URL = PROXY_BASE + '/tv';
+
+        // The service tries to take over via CDP and navigate this page to the real
+        // https://www.youtube.com/tv, which is the only way YouTube hands over a valid
+        // PO token and actually serves video (see standalone/service/cdp.js).
+        //
+        // Progress is reported on screen because the loopback ADB connection the takeover
+        // needs requires developer mode's Host PC IP to be 127.0.0.1, and with that set
+        // there is no sdb access left to read logs over.
+        //
+        // Deliberately no reload loop: the previous version reloaded whenever the proxy
+        // was not answering, which is what presented as an endless black screen.
+        // The handover plus its one retry can run for roughly 40s, so do not give up
+        // before it has had a chance to finish.
+        const FALLBACK_AFTER_MS = 60000;
+        const EXIT_MARKER = 'tt-exit-for-debug-at';
+        const startedAt = Date.now();
+        let fellBack = false;
+        let exiting = false;
+
+        function show(phase, detail) {
+            const phaseEl = document.getElementById('phase');
+            const detailEl = document.getElementById('detail');
+            if (phaseEl) phaseEl.textContent = phase;
+            if (detailEl) detailEl.textContent = detail || '';
+        }
+
+        // Deliberately slow: when direct mode fails this screen is the only diagnostic
+        // channel available, because the loopback ADB connection needs Host PC IP set to
+        // 127.0.0.1 and that leaves no sdb access from a PC. Give a real chance to read
+        // (or photograph) the trace before the page navigates away.
+        function fallBackToProxy(why, tail) {
+            if (fellBack) return;
+            fellBack = true;
+
+            let left = 25;
+            const tick = function () {
+                show('Starting in proxy mode in ' + left + 's',
+                    why + '\n\n' + (tail || '') +
+                    '\n\nBrowsing works; video playback may fail.');
+                if (left <= 0) return location.href = PROXY_FALLBACK_URL;
+                left--;
+                setTimeout(tick, 1000);
+            };
+            tick();
+        }
+
+        function poll() {
+            fetch(PROXY_BASE + '/tizentube/cdp-status')
+                .then(function (res) { return res.json(); })
+                .then(function (status) {
+                    const tail = (status.log || []).slice(-14).join('\n');
+
+                    if (status.phase === 'ready' || status.navigated) {
+                        // The service has issued the navigation, so this document is
+                        // about to be replaced. Nothing left to do beyond clearing the
+                        // loop-breaker, since the restart demonstrably completed.
+                        try { localStorage.removeItem(EXIT_MARKER); } catch (e) { }
+                        show('Loading YouTube…', '');
+                        return;
+                    }
+
+                    // sdbd will not relaunch this app with debugging while it is sitting
+                    // in the foreground -- the stream opens and then goes silent. Step
+                    // out of the way so the service can relaunch us properly; the very
+                    // next thing that happens is this app starting again, in debug mode.
+                    // Normal path shows nothing but the splash. The handover replaces
+                    // this app with a debug-enabled one, and the replacement shows the
+                    // same screen, so it reads as one continuous load rather than a
+                    // crash-and-reopen. Diagnostics are kept for the failure path only.
+                    if (status.action === 'exit-for-debug' && !exiting) {
+                        // Loop-breaker: if closing the app also tears the service down,
+                        // the relaunched app would be asked to close again immediately
+                        // and the TV would sit in a self-closing loop. Only honour this
+                        // once in any two minute window.
+                        let lastExit = 0;
+                        try { lastExit = Number(localStorage.getItem(EXIT_MARKER) || 0); } catch (e) { }
+
+                        if (Date.now() - lastExit < 120000) {
+                            return fallBackToProxy(
+                                'Direct mode needs the app to restart, but the last restart ' +
+                                'did not complete. Skipping to avoid a restart loop.', tail);
+                        }
+
+                        exiting = true;
+                        try { localStorage.setItem(EXIT_MARKER, String(Date.now())); } catch (e) { }
+                        show('Loading…', '');
+                        return setTimeout(function () {
+                            try {
+                                tizen.application.getCurrentApplication().exit();
+                            } catch (e) {
+                                show('Could not close for restart', String(e));
+                            }
+                        }, 700);
+                    }
+
+                    if (status.phase === 'failed') {
+                        return fallBackToProxy('Direct mode unavailable: ' + status.error, tail);
+                    }
+
+                    show('Loading…', '');
+
+                    if (Date.now() - startedAt > FALLBACK_AFTER_MS) {
+                        return fallBackToProxy('Direct mode timed out at stage: ' + status.phase, tail);
+                    }
+                    setTimeout(poll, 600);
+                })
+                .catch(function () {
+                    // Service not up yet, or an older build without CDP support.
+                    if (Date.now() - startedAt > FALLBACK_AFTER_MS) {
+                        return fallBackToProxy('Service did not report status.');
+                    }
+                    show('Loading…', '');
+                    setTimeout(poll, 600);
+                });
+        }
+
         const pkgId = tizen.application.getCurrentApplication().appInfo.packageId;
 
         const serviceId = pkgId + ".StandaloneService";
@@ -35,22 +181,20 @@
         tizen.application.launchAppControl(
             new tizen.ApplicationControl("http://tizen.org/appcontrol/operation/service"),
             serviceId,
-            function () {
-                fetch('http://localhost:8099/tv').then(a => {
-                    location.href = 'http://localhost:8099/tv';
-                }).catch(b => {
-                    window.location.reload();
-                })
-            },
+            function () { poll(); },
             function (e) {
-                alert("Launch Service failed: " + e.message);
+                show('Could not start the TizenTube service', e.message);
             }
         );
     </script>
 </head>
 
 <body>
-
+    <div id="boot">
+        <h1>TizenTube</h1>
+        <div id="phase">Starting service&hellip;</div>
+        <div id="detail"></div>
+    </div>
 </body>
 
 </html>

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -58,119 +58,52 @@
 
         const PROXY_BASE = 'http://localhost:8099';
         const PROXY_FALLBACK_URL = PROXY_BASE + '/tv';
-
-        // The service tries to take over via CDP and navigate this page to the real
-        // https://www.youtube.com/tv, which is the only way YouTube hands over a valid
-        // PO token and actually serves video (see standalone/service/cdp.js).
-        //
-        // Progress is reported on screen because the loopback ADB connection the takeover
-        // needs requires developer mode's Host PC IP to be 127.0.0.1, and with that set
-        // there is no sdb access left to read logs over.
-        //
-        // Deliberately no reload loop: the previous version reloaded whenever the proxy
-        // was not answering, which is what presented as an endless black screen.
-        // The handover plus its one retry can run for roughly 40s, so do not give up
-        // before it has had a chance to finish.
-        const FALLBACK_AFTER_MS = 60000;
-        const EXIT_MARKER = 'tt-exit-for-debug-at';
+        const FALLBACK_AFTER_MS = 20000;
         const startedAt = Date.now();
         let fellBack = false;
         let exiting = false;
 
-        function show(phase, detail) {
+        function show(text, detail) {
             const phaseEl = document.getElementById('phase');
             const detailEl = document.getElementById('detail');
-            if (phaseEl) phaseEl.textContent = phase;
+            if (phaseEl) phaseEl.textContent = text;
             if (detailEl) detailEl.textContent = detail || '';
         }
 
-        // Deliberately slow: when direct mode fails this screen is the only diagnostic
-        // channel available, because the loopback ADB connection needs Host PC IP set to
-        // 127.0.0.1 and that leaves no sdb access from a PC. Give a real chance to read
-        // (or photograph) the trace before the page navigates away.
-        function fallBackToProxy(why, tail) {
+        function fallBackToProxy(why) {
             if (fellBack) return;
             fellBack = true;
-
-            let left = 25;
-            const tick = function () {
-                show('Starting in proxy mode in ' + left + 's',
-                    why + '\n\n' + (tail || '') +
-                    '\n\nBrowsing works; video playback may fail.');
-                if (left <= 0) return location.href = PROXY_FALLBACK_URL;
-                left--;
-                setTimeout(tick, 1000);
-            };
-            tick();
+            show('Loading…', why);
+            setTimeout(function () { location.href = PROXY_FALLBACK_URL; }, 4000);
         }
 
         function poll() {
             fetch(PROXY_BASE + '/tizentube/cdp-status')
                 .then(function (res) { return res.json(); })
                 .then(function (status) {
-                    const tail = (status.log || []).slice(-14).join('\n');
+                    if (status.phase === 'ready') return show('Loading…', '');
 
-                    if (status.phase === 'ready' || status.navigated) {
-                        // The service has issued the navigation, so this document is
-                        // about to be replaced. Nothing left to do beyond clearing the
-                        // loop-breaker, since the restart demonstrably completed.
-                        try { localStorage.removeItem(EXIT_MARKER); } catch (e) { }
-                        show('Loading YouTube…', '');
-                        return;
-                    }
-
-                    // sdbd will not relaunch this app with debugging while it is sitting
-                    // in the foreground -- the stream opens and then goes silent. Step
-                    // out of the way so the service can relaunch us properly; the very
-                    // next thing that happens is this app starting again, in debug mode.
-                    // Normal path shows nothing but the splash. The handover replaces
-                    // this app with a debug-enabled one, and the replacement shows the
-                    // same screen, so it reads as one continuous load rather than a
-                    // crash-and-reopen. Diagnostics are kept for the failure path only.
                     if (status.action === 'exit-for-debug' && !exiting) {
-                        // Loop-breaker: if closing the app also tears the service down,
-                        // the relaunched app would be asked to close again immediately
-                        // and the TV would sit in a self-closing loop. Only honour this
-                        // once in any two minute window.
-                        let lastExit = 0;
-                        try { lastExit = Number(localStorage.getItem(EXIT_MARKER) || 0); } catch (e) { }
-
-                        if (Date.now() - lastExit < 120000) {
-                            return fallBackToProxy(
-                                'Direct mode needs the app to restart, but the last restart ' +
-                                'did not complete. Skipping to avoid a restart loop.', tail);
-                        }
-
                         exiting = true;
-                        try { localStorage.setItem(EXIT_MARKER, String(Date.now())); } catch (e) { }
-                        show('Loading…', '');
-                        return setTimeout(function () {
-                            try {
+                        return fetch(PROXY_BASE + '/tizentube/exiting', { method: 'POST' })
+                            .then(function () {
                                 tizen.application.getCurrentApplication().exit();
-                            } catch (e) {
-                                show('Could not close for restart', String(e));
-                            }
-                        }, 700);
+                            })
+                            .catch(function () {
+                                tizen.application.getCurrentApplication().exit();
+                            });
                     }
 
-                    if (status.phase === 'failed') {
-                        return fallBackToProxy('Direct mode unavailable: ' + status.error, tail);
-                    }
-
-                    show('Loading…', '');
+                    if (status.phase === 'failed') return fallBackToProxy(status.error || '');
 
                     if (Date.now() - startedAt > FALLBACK_AFTER_MS) {
-                        return fallBackToProxy('Direct mode timed out at stage: ' + status.phase, tail);
+                        return fallBackToProxy('');
                     }
-                    setTimeout(poll, 600);
+                    setTimeout(poll, 400);
                 })
                 .catch(function () {
-                    // Service not up yet, or an older build without CDP support.
-                    if (Date.now() - startedAt > FALLBACK_AFTER_MS) {
-                        return fallBackToProxy('Service did not report status.');
-                    }
-                    show('Loading…', '');
-                    setTimeout(poll, 600);
+                    if (Date.now() - startedAt > FALLBACK_AFTER_MS) return fallBackToProxy('');
+                    setTimeout(poll, 400);
                 });
         }
 

--- a/standalone/service/cdp.js
+++ b/standalone/service/cdp.js
@@ -1,0 +1,325 @@
+"use strict";
+
+// Userscript injection over the Chrome DevTools Protocol.
+//
+// Why this exists: the proxy serves youtube.com from http://localhost:8099, and YouTube
+// binds its Proof-of-Origin token to the page origin. With the wrong origin every SABR
+// media POST comes back as a six-byte "stream protection status = 3 (PoToken required)"
+// message and no video at all -- that is upstream #555 / #561, confirmed on hardware.
+// Loading the real https://www.youtube.com/tv fixes it, but the page is then cross-origin
+// and cannot be scripted by the app, so the userscript goes in over CDP instead. This is
+// the same mechanism TizenBrew's module loader uses (service-nextgen/service/utils/
+// debugger.js), which is why the TizenBrew module never had the problem.
+//
+// Requires developer mode ON with Host PC IP == 127.0.0.1. sdbd accepts a loopback TCP
+// connection whatever that field says, but only completes the ADB handshake when the
+// configured host matches the peer -- with a LAN IP configured the socket opens and then
+// stays silent forever.
+
+const net = require('net');
+const CDP = require('chrome-remote-interface');
+const fetch = require('node-fetch');
+
+const SDB_PORT = 26101;
+const UI_APP_ID = 'xvvl3S1TT1.TizenTubeStandalone';
+
+// Matches the module's websiteURL in the repo root package.json.
+const YOUTUBE_TV_URL =
+    'https://www.youtube.com/tv?additionalDataUrl=' +
+    encodeURIComponent('http://localhost:8085/dial/apps/YouTube');
+
+const state = {
+    phase: 'idle',
+    attached: false,
+    navigated: false,
+    port: null,
+    error: null,
+    bypassedCsp: false,
+    injectedVia: null,
+    // Set to 'exit-for-debug' to ask index.html to close itself; see the retry ladder in
+    // start() for why that helps.
+    action: null,
+    log: []
+};
+
+function record(message) {
+    state.log.push(new Date().toISOString().substr(11, 8) + ' ' + message);
+    if (state.log.length > 60) state.log.shift();
+    console.log('[TizenTube CDP] ' + message);
+}
+
+function fail(phase, error) {
+    state.phase = 'failed';
+    state.error = (error && error.message ? error.message : String(error));
+    record('FAILED at ' + phase + ': ' + state.error);
+}
+
+// --- minimal ADB/SDB host client -------------------------------------------------
+//
+// Hand-rolled rather than using the adbhost package. adbhost is unmaintained, ignores
+// AUTH packets outright (there is a literal "TODO: handle AUTH" in its dispatcher), and
+// reads its socket in 'readable' mode -- which also means any 'data' listener added for
+// instrumentation never fires, so it silently hides what the device actually replied.
+// Doing the framing here means every byte in both directions can be logged to screen.
+
+const A_CNXN = 0x4e584e43;
+const A_OPEN = 0x4e45504f;
+const A_OKAY = 0x59414b4f;
+const A_WRTE = 0x45545257;
+const A_CLSE = 0x45534c43;
+const A_AUTH = 0x48545541;
+
+function commandName(cmd) {
+    switch (cmd) {
+        case A_CNXN: return 'CNXN';
+        case A_OPEN: return 'OPEN';
+        case A_OKAY: return 'OKAY';
+        case A_WRTE: return 'WRTE';
+        case A_CLSE: return 'CLSE';
+        case A_AUTH: return 'AUTH';
+        default: return '0x' + (cmd >>> 0).toString(16);
+    }
+}
+
+function adbPacket(command, arg0, arg1, payload) {
+    const data = payload ? Buffer.from(payload, 'latin1') : Buffer.alloc(0);
+    let checksum = 0;
+    for (let i = 0; i < data.length; i++) checksum = (checksum + data[i]) >>> 0;
+
+    const header = Buffer.alloc(24);
+    header.writeUInt32LE(command >>> 0, 0);
+    header.writeUInt32LE(arg0 >>> 0, 4);
+    header.writeUInt32LE(arg1 >>> 0, 8);
+    header.writeUInt32LE(data.length, 12);
+    header.writeUInt32LE(checksum, 16);
+    header.writeUInt32LE((command ^ 0xffffffff) >>> 0, 20);
+    return Buffer.concat([header, data]);
+}
+
+// Ask the TV's own sdbd to relaunch our UI app with remote debugging enabled, and read
+// the port out of its reply.
+function getDebugPort(timeoutMs) {
+    return new Promise((resolve, reject) => {
+        let settled = false;
+        const done = (fn, arg) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            try { socket.destroy(); } catch (e) { }
+            fn(arg);
+        };
+
+        const timer = setTimeout(() => {
+            done(reject, new Error('timeout; last state: ' + phase + ', rx=' + rxCount + ' pkts'));
+        }, timeoutMs || 12000);
+
+        let phase = 'connecting';
+        let rxCount = 0;
+        let buffer = Buffer.alloc(0);
+        let shellOut = '';
+        const localId = 12345;
+        let remoteId = 0;
+
+        const socket = net.connect({ host: '127.0.0.1', port: SDB_PORT });
+        socket.on('error', (e) => done(reject, new Error('socket ' + phase + ': ' + e.message)));
+        socket.on('close', () => {
+            record('socket closed (phase ' + phase + ', ' + rxCount + ' packets in)');
+            if (!tryParsePort()) {
+                done(reject, new Error('closed during ' + phase + '; shell said: ' +
+                    JSON.stringify(shellOut.substr(0, 120))));
+            }
+        });
+
+        socket.on('connect', () => {
+            phase = 'sent-CNXN';
+            record('TCP connected to sdbd, sending CNXN');
+            socket.write(adbPacket(A_CNXN, 0x01000000, 4096, 'host::\0'));
+        });
+
+        function tryParsePort() {
+            const match = shellOut.match(/port:\s*(\d+)/);
+            if (!match) return false;
+            record('shell reply: ' + shellOut.trim().substr(0, 90));
+            done(resolve, Number(match[1]));
+            return true;
+        }
+
+        function handlePacket(cmd, arg0, arg1, payload) {
+            rxCount++;
+            const name = commandName(cmd);
+
+            if (cmd === A_CNXN) {
+                record('<- CNXN banner=' + JSON.stringify(payload.toString('latin1').substr(0, 60)));
+                phase = 'sent-OPEN';
+                socket.write(adbPacket(A_OPEN, localId, 0, 'shell:0 debug ' + UI_APP_ID + '\0'));
+                return;
+            }
+
+            if (cmd === A_AUTH) {
+                // Worth knowing explicitly: it would mean sdbd wants an RSA handshake,
+                // which is a completely different problem from a silent connection.
+                record('<- AUTH type=' + arg0 + ' (device demands key exchange)');
+                done(reject, new Error('sdbd requires AUTH (type ' + arg0 + ')'));
+                return;
+            }
+
+            if (cmd === A_OKAY) {
+                if (!remoteId) remoteId = arg0;
+                record('<- OKAY remote=' + arg0);
+                return;
+            }
+
+            if (cmd === A_WRTE) {
+                remoteId = remoteId || arg0;
+                shellOut += payload.toString('latin1');
+                socket.write(adbPacket(A_OKAY, localId, remoteId, null));
+                tryParsePort();
+                return;
+            }
+
+            if (cmd === A_CLSE) {
+                record('<- CLSE');
+                if (!tryParsePort()) {
+                    done(reject, new Error('stream closed; shell said: ' +
+                        JSON.stringify(shellOut.substr(0, 120))));
+                }
+                return;
+            }
+
+            record('<- ' + name + ' (unhandled) len=' + payload.length);
+        }
+
+        socket.on('data', (chunk) => {
+            if (rxCount === 0) {
+                record('first bytes in: ' + chunk.slice(0, 24).toString('hex'));
+            }
+            buffer = Buffer.concat([buffer, chunk]);
+            while (buffer.length >= 24) {
+                const cmd = buffer.readUInt32LE(0);
+                const arg0 = buffer.readUInt32LE(4);
+                const arg1 = buffer.readUInt32LE(8);
+                const len = buffer.readUInt32LE(12);
+                if (len > 4 * 1024 * 1024) {
+                    return done(reject, new Error('bad frame len ' + len +
+                        ' hdr=' + buffer.slice(0, 24).toString('hex')));
+                }
+                if (buffer.length < 24 + len) break;
+                const payload = buffer.slice(24, 24 + len);
+                buffer = buffer.slice(24 + len);
+                handlePacket(cmd, arg0, arg1, payload);
+                if (settled) return;
+            }
+        });
+    });
+}
+
+function attach(port, options) {
+    return CDP({ port: port, host: '127.0.0.1', local: true }).then((client) => {
+        record('CDP client connected on ' + port);
+
+        const enable = client.Page.enable()
+            .then(() => client.Runtime.enable())
+            .then(() => client.Network.enable().catch(() => {
+                record('Network.enable unsupported, continuing');
+            }));
+
+        return enable
+            .then(() => {
+                // The proxy used to strip content-security-policy from every response
+                // (see skipHeaders in index.js). Nothing is proxied on this path, so the
+                // page gets YouTube's real CSP -- which is what #74 describes as blocking
+                // SponsorBlock and DeArrow. This is the replacement for that stripping.
+                return client.Page.setBypassCSP({ enabled: true })
+                    .then(() => {
+                        state.bypassedCsp = true;
+                        record('CSP bypass enabled');
+                    })
+                    .catch((e) => record('Page.setBypassCSP unsupported: ' + e.message));
+            })
+            .then(() => fetch(options.userScriptUrl).then((r) => r.text()))
+            .then((source) => {
+                record('userscript fetched (' + source.length + ' bytes)');
+
+                // Preferred: runs before any of YouTube's own scripts on every document.
+                return client.Page.addScriptToEvaluateOnNewDocument({ expression: source })
+                    .then(() => {
+                        state.injectedVia = 'addScriptToEvaluateOnNewDocument';
+                        record('injection armed at document start');
+                    })
+                    .catch((e) => {
+                        // Older protocol builds: inject per execution context instead.
+                        record('addScriptToEvaluateOnNewDocument unsupported (' + e.message + '), falling back');
+                        state.injectedVia = 'Runtime.evaluate';
+                        client.on('Runtime.executionContextCreated', (msg) => {
+                            client.Runtime.evaluate({
+                                expression: source,
+                                contextId: msg.context.id
+                            }).catch((err) => record('evaluate failed: ' + err.message));
+                        });
+                    });
+            })
+            .then(() => {
+                state.attached = true;
+                state.phase = 'navigating';
+                record('navigating to the real youtube.com');
+                return client.Page.navigate({ url: YOUTUBE_TV_URL });
+            })
+            .then(() => {
+                state.navigated = true;
+                state.phase = 'ready';
+                record('navigation issued -- real origin, script injected');
+            });
+    });
+}
+
+// `shell:0 debug` restarts the UI app, so index.html runs a second time while this
+// service keeps living. Without a guard we would relaunch forever.
+let started = false;
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function start(options) {
+    if (started) {
+        record('start() ignored, already running');
+        return;
+    }
+    started = true;
+
+    // CDP only exists for an app that was *launched* with remote debugging, and on Tizen
+    // the only way to do that is `shell:0 debug <appid>` -- itself a launch. So the app
+    // the user just opened has to be replaced by a debug-enabled one.
+    //
+    // It has to get out of the way first: sdbd opens the stream and then goes silent if
+    // the target app is in the foreground (reproduced from a PC too, where the same
+    // command timed out with the app up and returned instantly from the home screen).
+    // Asking up front costs one quick restart; waiting for the foreground attempt to
+    // stall first just adds a visible pause before the same restart.
+    state.phase = 'restarting';
+    state.action = 'exit-for-debug';
+    record('asking the UI app to close so sdbd can relaunch it with debugging');
+
+    delay(1800)
+        .then(() => {
+            state.action = null;
+            state.phase = 'connecting-sdb';
+            return getDebugPort(15000);
+        })
+        .catch((e) => {
+            // The app may not have exited (an old page, or exit refused). One more go
+            // with a longer window rather than giving up on direct mode outright.
+            record('first debug launch failed: ' + e.message + ' -- retrying');
+            state.phase = 'connecting-sdb';
+            return getDebugPort(20000);
+        })
+        .then((port) => {
+            state.port = port;
+            state.phase = 'attaching';
+            record('debug port ' + port);
+            return attach(port, options);
+        })
+        .catch((e) => fail(state.phase, e));
+}
+
+module.exports = { start: start, state: state, YOUTUBE_TV_URL: YOUTUBE_TV_URL };

--- a/standalone/service/cdp.js
+++ b/standalone/service/cdp.js
@@ -1,325 +1,179 @@
 "use strict";
 
-// Userscript injection over the Chrome DevTools Protocol.
-//
-// Why this exists: the proxy serves youtube.com from http://localhost:8099, and YouTube
-// binds its Proof-of-Origin token to the page origin. With the wrong origin every SABR
-// media POST comes back as a six-byte "stream protection status = 3 (PoToken required)"
-// message and no video at all -- that is upstream #555 / #561, confirmed on hardware.
-// Loading the real https://www.youtube.com/tv fixes it, but the page is then cross-origin
-// and cannot be scripted by the app, so the userscript goes in over CDP instead. This is
-// the same mechanism TizenBrew's module loader uses (service-nextgen/service/utils/
-// debugger.js), which is why the TizenBrew module never had the problem.
-//
-// Requires developer mode ON with Host PC IP == 127.0.0.1. sdbd accepts a loopback TCP
-// connection whatever that field says, but only completes the ADB handshake when the
-// configured host matches the peer -- with a LAN IP configured the socket opens and then
-// stays silent forever.
-
-const net = require('net');
+const adbhost = require('adbhost');
 const CDP = require('chrome-remote-interface');
 const fetch = require('node-fetch');
+const os = require('os');
 
 const SDB_PORT = 26101;
-const UI_APP_ID = 'xvvl3S1TT1.TizenTubeStandalone';
-
-// Matches the module's websiteURL in the repo root package.json.
-const YOUTUBE_TV_URL =
-    'https://www.youtube.com/tv?additionalDataUrl=' +
+const DEVICE_API = 'http://127.0.0.1:8001/api/v2/';
+const UI_APP_SUFFIX = '.TizenTubeStandalone';
+const YOUTUBE_TV_URL = 'https://www.youtube.com/tv?additionalDataUrl=' +
     encodeURIComponent('http://localhost:8085/dial/apps/YouTube');
 
 const state = {
     phase: 'idle',
-    attached: false,
-    navigated: false,
-    port: null,
-    error: null,
-    bypassedCsp: false,
-    injectedVia: null,
-    // Set to 'exit-for-debug' to ask index.html to close itself; see the retry ladder in
-    // start() for why that helps.
     action: null,
-    log: []
+    error: null
 };
 
-function record(message) {
-    state.log.push(new Date().toISOString().substr(11, 8) + ' ' + message);
-    if (state.log.length > 60) state.log.shift();
-    console.log('[TizenTube CDP] ' + message);
-}
-
-function fail(phase, error) {
-    state.phase = 'failed';
-    state.error = (error && error.message ? error.message : String(error));
-    record('FAILED at ' + phase + ': ' + state.error);
-}
-
-// --- minimal ADB/SDB host client -------------------------------------------------
-//
-// Hand-rolled rather than using the adbhost package. adbhost is unmaintained, ignores
-// AUTH packets outright (there is a literal "TODO: handle AUTH" in its dispatcher), and
-// reads its socket in 'readable' mode -- which also means any 'data' listener added for
-// instrumentation never fires, so it silently hides what the device actually replied.
-// Doing the framing here means every byte in both directions can be logged to screen.
-
-const A_CNXN = 0x4e584e43;
-const A_OPEN = 0x4e45504f;
-const A_OKAY = 0x59414b4f;
-const A_WRTE = 0x45545257;
-const A_CLSE = 0x45534c43;
-const A_AUTH = 0x48545541;
-
-function commandName(cmd) {
-    switch (cmd) {
-        case A_CNXN: return 'CNXN';
-        case A_OPEN: return 'OPEN';
-        case A_OKAY: return 'OKAY';
-        case A_WRTE: return 'WRTE';
-        case A_CLSE: return 'CLSE';
-        case A_AUTH: return 'AUTH';
-        default: return '0x' + (cmd >>> 0).toString(16);
+const isTizen3 = (function () {
+    try {
+        return tizen.systeminfo
+            .getCapability('http://tizen.org/feature/platform.version')
+            .startsWith('3.0');
+    } catch (e) {
+        return false;
     }
+})();
+
+function uiAppId() {
+    return tizen.application.getAppInfo().packageId + UI_APP_SUFFIX;
 }
 
-function adbPacket(command, arg0, arg1, payload) {
-    const data = payload ? Buffer.from(payload, 'latin1') : Buffer.alloc(0);
-    let checksum = 0;
-    for (let i = 0; i < data.length; i++) checksum = (checksum + data[i]) >>> 0;
-
-    const header = Buffer.alloc(24);
-    header.writeUInt32LE(command >>> 0, 0);
-    header.writeUInt32LE(arg0 >>> 0, 4);
-    header.writeUInt32LE(arg1 >>> 0, 8);
-    header.writeUInt32LE(data.length, 12);
-    header.writeUInt32LE(checksum, 16);
-    header.writeUInt32LE((command ^ 0xffffffff) >>> 0, 20);
-    return Buffer.concat([header, data]);
-}
-
-// Ask the TV's own sdbd to relaunch our UI app with remote debugging enabled, and read
-// the port out of its reply.
-function getDebugPort(timeoutMs) {
-    return new Promise((resolve, reject) => {
-        let settled = false;
-        const done = (fn, arg) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            try { socket.destroy(); } catch (e) { }
-            fn(arg);
-        };
-
-        const timer = setTimeout(() => {
-            done(reject, new Error('timeout; last state: ' + phase + ', rx=' + rxCount + ' pkts'));
-        }, timeoutMs || 12000);
-
-        let phase = 'connecting';
-        let rxCount = 0;
-        let buffer = Buffer.alloc(0);
-        let shellOut = '';
-        const localId = 12345;
-        let remoteId = 0;
-
-        const socket = net.connect({ host: '127.0.0.1', port: SDB_PORT });
-        socket.on('error', (e) => done(reject, new Error('socket ' + phase + ': ' + e.message)));
-        socket.on('close', () => {
-            record('socket closed (phase ' + phase + ', ' + rxCount + ' packets in)');
-            if (!tryParsePort()) {
-                done(reject, new Error('closed during ' + phase + '; shell said: ' +
-                    JSON.stringify(shellOut.substr(0, 120))));
-            }
-        });
-
-        socket.on('connect', () => {
-            phase = 'sent-CNXN';
-            record('TCP connected to sdbd, sending CNXN');
-            socket.write(adbPacket(A_CNXN, 0x01000000, 4096, 'host::\0'));
-        });
-
-        function tryParsePort() {
-            const match = shellOut.match(/port:\s*(\d+)/);
-            if (!match) return false;
-            record('shell reply: ' + shellOut.trim().substr(0, 90));
-            done(resolve, Number(match[1]));
-            return true;
+function tvAddress() {
+    const interfaces = os.networkInterfaces();
+    for (const name in interfaces) {
+        for (const entry of interfaces[name]) {
+            if (entry.family === 'IPv4' && !entry.internal) return entry.address;
         }
-
-        function handlePacket(cmd, arg0, arg1, payload) {
-            rxCount++;
-            const name = commandName(cmd);
-
-            if (cmd === A_CNXN) {
-                record('<- CNXN banner=' + JSON.stringify(payload.toString('latin1').substr(0, 60)));
-                phase = 'sent-OPEN';
-                socket.write(adbPacket(A_OPEN, localId, 0, 'shell:0 debug ' + UI_APP_ID + '\0'));
-                return;
-            }
-
-            if (cmd === A_AUTH) {
-                // Worth knowing explicitly: it would mean sdbd wants an RSA handshake,
-                // which is a completely different problem from a silent connection.
-                record('<- AUTH type=' + arg0 + ' (device demands key exchange)');
-                done(reject, new Error('sdbd requires AUTH (type ' + arg0 + ')'));
-                return;
-            }
-
-            if (cmd === A_OKAY) {
-                if (!remoteId) remoteId = arg0;
-                record('<- OKAY remote=' + arg0);
-                return;
-            }
-
-            if (cmd === A_WRTE) {
-                remoteId = remoteId || arg0;
-                shellOut += payload.toString('latin1');
-                socket.write(adbPacket(A_OKAY, localId, remoteId, null));
-                tryParsePort();
-                return;
-            }
-
-            if (cmd === A_CLSE) {
-                record('<- CLSE');
-                if (!tryParsePort()) {
-                    done(reject, new Error('stream closed; shell said: ' +
-                        JSON.stringify(shellOut.substr(0, 120))));
-                }
-                return;
-            }
-
-            record('<- ' + name + ' (unhandled) len=' + payload.length);
-        }
-
-        socket.on('data', (chunk) => {
-            if (rxCount === 0) {
-                record('first bytes in: ' + chunk.slice(0, 24).toString('hex'));
-            }
-            buffer = Buffer.concat([buffer, chunk]);
-            while (buffer.length >= 24) {
-                const cmd = buffer.readUInt32LE(0);
-                const arg0 = buffer.readUInt32LE(4);
-                const arg1 = buffer.readUInt32LE(8);
-                const len = buffer.readUInt32LE(12);
-                if (len > 4 * 1024 * 1024) {
-                    return done(reject, new Error('bad frame len ' + len +
-                        ' hdr=' + buffer.slice(0, 24).toString('hex')));
-                }
-                if (buffer.length < 24 + len) break;
-                const payload = buffer.slice(24, 24 + len);
-                buffer = buffer.slice(24 + len);
-                handlePacket(cmd, arg0, arg1, payload);
-                if (settled) return;
-            }
-        });
-    });
+    }
+    return '127.0.0.1';
 }
 
-function attach(port, options) {
-    return CDP({ port: port, host: '127.0.0.1', local: true }).then((client) => {
-        record('CDP client connected on ' + port);
-
-        const enable = client.Page.enable()
-            .then(() => client.Runtime.enable())
-            .then(() => client.Network.enable().catch(() => {
-                record('Network.enable unsupported, continuing');
-            }));
-
-        return enable
-            .then(() => {
-                // The proxy used to strip content-security-policy from every response
-                // (see skipHeaders in index.js). Nothing is proxied on this path, so the
-                // page gets YouTube's real CSP -- which is what #74 describes as blocking
-                // SponsorBlock and DeArrow. This is the replacement for that stripping.
-                return client.Page.setBypassCSP({ enabled: true })
-                    .then(() => {
-                        state.bypassedCsp = true;
-                        record('CSP bypass enabled');
-                    })
-                    .catch((e) => record('Page.setBypassCSP unsupported: ' + e.message));
-            })
-            .then(() => fetch(options.userScriptUrl).then((r) => r.text()))
-            .then((source) => {
-                record('userscript fetched (' + source.length + ' bytes)');
-
-                // Preferred: runs before any of YouTube's own scripts on every document.
-                return client.Page.addScriptToEvaluateOnNewDocument({ expression: source })
-                    .then(() => {
-                        state.injectedVia = 'addScriptToEvaluateOnNewDocument';
-                        record('injection armed at document start');
-                    })
-                    .catch((e) => {
-                        // Older protocol builds: inject per execution context instead.
-                        record('addScriptToEvaluateOnNewDocument unsupported (' + e.message + '), falling back');
-                        state.injectedVia = 'Runtime.evaluate';
-                        client.on('Runtime.executionContextCreated', (msg) => {
-                            client.Runtime.evaluate({
-                                expression: source,
-                                contextId: msg.context.id
-                            }).catch((err) => record('evaluate failed: ' + err.message));
-                        });
-                    });
-            })
-            .then(() => {
-                state.attached = true;
-                state.phase = 'navigating';
-                record('navigating to the real youtube.com');
-                return client.Page.navigate({ url: YOUTUBE_TV_URL });
-            })
-            .then(() => {
-                state.navigated = true;
-                state.phase = 'ready';
-                record('navigation issued -- real origin, script injected');
-            });
-    });
+function canLaunchInDebug() {
+    return fetch(DEVICE_API)
+        .then((res) => res.json())
+        .then((json) =>
+            (json.device.developerIP === '127.0.0.1' || json.device.developerIP === '1.0.0.127') &&
+            json.device.developerMode === '1')
+        .catch(() => false);
 }
-
-// `shell:0 debug` restarts the UI app, so index.html runs a second time while this
-// service keeps living. Without a guard we would relaunch forever.
-let started = false;
 
 function delay(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function start(options) {
-    if (started) {
-        record('start() ignored, already running');
-        return;
-    }
-    started = true;
+let exitAcked = false;
 
-    // CDP only exists for an app that was *launched* with remote debugging, and on Tizen
-    // the only way to do that is `shell:0 debug <appid>` -- itself a launch. So the app
-    // the user just opened has to be replaced by a debug-enabled one.
-    //
-    // It has to get out of the way first: sdbd opens the stream and then goes silent if
-    // the target app is in the foreground (reproduced from a PC too, where the same
-    // command timed out with the app up and returned instantly from the home screen).
-    // Asking up front costs one quick restart; waiting for the foreground attempt to
-    // stall first just adds a visible pause before the same restart.
-    state.phase = 'restarting';
-    state.action = 'exit-for-debug';
-    record('asking the UI app to close so sdbd can relaunch it with debugging');
-
-    delay(1800)
-        .then(() => {
-            state.action = null;
-            state.phase = 'connecting-sdb';
-            return getDebugPort(15000);
-        })
-        .catch((e) => {
-            // The app may not have exited (an old page, or exit refused). One more go
-            // with a longer window rather than giving up on direct mode outright.
-            record('first debug launch failed: ' + e.message + ' -- retrying');
-            state.phase = 'connecting-sdb';
-            return getDebugPort(20000);
-        })
-        .then((port) => {
-            state.port = port;
-            state.phase = 'attaching';
-            record('debug port ' + port);
-            return attach(port, options);
-        })
-        .catch((e) => fail(state.phase, e));
+function noteExitAck() {
+    exitAcked = true;
 }
 
-module.exports = { start: start, state: state, YOUTUBE_TV_URL: YOUTUBE_TV_URL };
+function waitForExitAck(timeoutMs) {
+    const startedAt = Date.now();
+    return new Promise((resolve) => {
+        const check = () => {
+            if (exitAcked || Date.now() - startedAt > timeoutMs) return resolve(exitAcked);
+            setTimeout(check, 150);
+        };
+        check();
+    });
+}
+
+function getDebugPort() {
+    return new Promise((resolve, reject) => {
+        const conn = adbhost.createConnection({ host: '127.0.0.1', port: SDB_PORT });
+        let settled = false;
+
+        const timer = setTimeout(
+            () => finish(reject, new Error('sdbd did not return a debug port')), 8000);
+
+        function finish(fn, arg) {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            fn(arg);
+        }
+
+        conn._stream.on('error', (e) => finish(reject, e));
+        conn._stream.on('connect', () => {
+            const stream = conn.createStream(
+                'shell:0 debug ' + uiAppId() + (isTizen3 ? ' 0' : ''));
+
+            stream.on('data', (data) => {
+                const match = data.toString().match(/port:\s*(\d+)/);
+                if (!match) return;
+                finish(resolve, Number(match[1]));
+                setTimeout(() => {
+                    try { conn._stream.end(); } catch (e) { }
+                }, 1000);
+            });
+            stream.on('error', (e) => finish(reject, e));
+        });
+    });
+}
+
+let liveClient = null;
+
+function applyUserAgent(userAgent) {
+    if (!liveClient || !userAgent) return Promise.resolve(false);
+    return liveClient.Network.setUserAgentOverride({ userAgent: userAgent })
+        .catch(() => liveClient.Emulation.setUserAgentOverride({ userAgent: userAgent }))
+        .then(() => true)
+        .catch(() => false);
+}
+
+function attach(port, options) {
+    return CDP({ port: port, host: tvAddress(), local: true })
+        .catch(() => CDP({ port: port, host: '127.0.0.1', local: true }))
+        .then((client) => {
+            liveClient = client;
+
+            return client.Page.enable()
+                .then(() => client.Runtime.enable())
+                .then(() => client.Network.enable().catch(() => { }))
+                .then(() => client.Page.setBypassCSP({ enabled: true }).catch(() => { }))
+                .then(() => fetch(options.userScriptUrl).then((r) => r.text()))
+                .then((source) => client.Page
+                    .addScriptToEvaluateOnNewDocument({ expression: source })
+                    .catch(() => {
+                        client.on('Runtime.executionContextCreated', (msg) => {
+                            client.Runtime.evaluate({
+                                expression: source,
+                                contextId: msg.context.id
+                            }).catch(() => { });
+                        });
+                    }))
+                .then(() => {
+                    state.phase = 'ready';
+                    return client.Page.navigate({ url: YOUTUBE_TV_URL });
+                });
+        });
+}
+
+let started = false;
+
+function start(options) {
+    if (started) return;
+    started = true;
+
+    canLaunchInDebug()
+        .then((allowed) => {
+            if (!allowed) {
+                throw new Error('Developer mode must be on with Host PC IP set to 127.0.0.1');
+            }
+
+            state.phase = 'restarting';
+            state.action = 'exit-for-debug';
+            return waitForExitAck(6000);
+        })
+        .then((acked) => delay(acked ? 1200 : 300))
+        .then(() => {
+            state.action = null;
+            state.phase = 'connecting';
+            return getDebugPort();
+        })
+        .then((port) => attach(port, options))
+        .catch((e) => {
+            state.phase = 'failed';
+            state.error = e && e.message ? e.message : String(e);
+        });
+}
+
+module.exports = {
+    start: start,
+    state: state,
+    noteExitAck: noteExitAck,
+    applyUserAgent: applyUserAgent
+};

--- a/standalone/service/index.js
+++ b/standalone/service/index.js
@@ -22,21 +22,13 @@ app.use((req, res, next) => {
     next();
 });
 
-// Progress of the CDP handover, polled by index.html so it can show a loading screen and
-// fall back to the proxy if direct mode never comes up. Registered before the catch-all
-// so it isn't forwarded to YouTube.
 app.get('/tizentube/cdp-status', (req, res) => {
-    res.json({
-        phase: cdp.state.phase,
-        action: cdp.state.action,
-        attached: cdp.state.attached,
-        navigated: cdp.state.navigated,
-        port: cdp.state.port,
-        error: cdp.state.error,
-        bypassedCsp: cdp.state.bypassedCsp,
-        injectedVia: cdp.state.injectedVia,
-        log: cdp.state.log
-    });
+    res.json(cdp.state);
+});
+
+app.post('/tizentube/exiting', (req, res) => {
+    cdp.noteExitAck();
+    res.json({ ok: true });
 });
 
 app.all('*', (req, res) => {
@@ -188,8 +180,5 @@ app.all('*', (req, res) => {
 });
 
 app.listen(PORT, "127.0.0.1", () => {
-    // Serve the real youtube.com over CDP instead of proxying it. If any step fails the
-    // proxy above is still running and index.html falls back to it, so a TV without a
-    // usable loopback debug connection keeps the previous behaviour rather than breaking.
     cdp.start({ userScriptUrl: USERSCRIPT_URL });
 });

--- a/standalone/service/index.js
+++ b/standalone/service/index.js
@@ -8,6 +8,9 @@ const PORT = 8099;
 const fetch = require('node-fetch');
 const http = require('http');
 const URL = require('url');
+const cdp = require('./cdp.js');
+
+const USERSCRIPT_URL = 'https://cdn.jsdelivr.net/npm/@foxreis/tizentube/dist/userScript.js';
 
 app.use((req, res, next) => {
     res.setHeader('Access-Control-Allow-Origin', '*');
@@ -17,6 +20,23 @@ app.use((req, res, next) => {
         return res.status(200).end();
     }
     next();
+});
+
+// Progress of the CDP handover, polled by index.html so it can show a loading screen and
+// fall back to the proxy if direct mode never comes up. Registered before the catch-all
+// so it isn't forwarded to YouTube.
+app.get('/tizentube/cdp-status', (req, res) => {
+    res.json({
+        phase: cdp.state.phase,
+        action: cdp.state.action,
+        attached: cdp.state.attached,
+        navigated: cdp.state.navigated,
+        port: cdp.state.port,
+        error: cdp.state.error,
+        bypassedCsp: cdp.state.bypassedCsp,
+        injectedVia: cdp.state.injectedVia,
+        log: cdp.state.log
+    });
 });
 
 app.all('*', (req, res) => {
@@ -167,4 +187,9 @@ app.all('*', (req, res) => {
         });
 });
 
-app.listen(PORT, "127.0.0.1");
+app.listen(PORT, "127.0.0.1", () => {
+    // Serve the real youtube.com over CDP instead of proxying it. If any step fails the
+    // proxy above is still running and index.html falls back to it, so a TV without a
+    // usable loopback debug connection keeps the previous behaviour rather than breaking.
+    cdp.start({ userScriptUrl: USERSCRIPT_URL });
+});

--- a/standalone/service/package.json
+++ b/standalone/service/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "chrome-remote-interface": "^0.25.7",
     "express": "^4.22.2",
     "node-fetch": "^2.7.0"
   },

--- a/standalone/service/package.json
+++ b/standalone/service/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "adbhost": "^0.0.2",
     "chrome-remote-interface": "^0.25.7",
     "express": "^4.22.2",
     "node-fetch": "^2.7.0"


### PR DESCRIPTION
Fixes [#555](https://github.com/reisxd/TizenTube/issues/555)
Fixes [#561](https://github.com/reisxd/TizenTube/issues/561)

## Depends on [#573](https://github.com/reisxd/TizenTube/pull/573)

Please merge [#573](https://github.com/reisxd/TizenTube/pull/573) first. In direct mode the page loads straight from youtube.com and never touches the proxy, but the proxy remains as the fallback path in this PR — and without [#573](https://github.com/reisxd/TizenTube/pull/573) that fallback still black-screens on the header-overflow bug. Merged on its own, this PR fixes playback but leaves a broken fallback.

## The bug

Standalone serves youtube.com through the local proxy on `http://localhost:8099`. YouTube binds its Proof-of-Origin token to the page origin, so with the wrong origin it simply refuses to hand over media.

Every SABR/UMP media POST returns HTTP 200 carrying exactly six bytes:

```
3a 04 08 03 10 0a
```

That decodes to a stream-protection message with **status 3** — *"requires a PoToken, interrupt playback immediately"*. No media bytes are ever sent. The player then reports `net.timeout:fatal` in its `/api/stats/qoe` beacon and shows "something went wrong" with a QR code.

That is [#555](https://github.com/reisxd/TizenTube/issues/555). [#561](https://github.com/reisxd/TizenTube/issues/561) is the same fault seen after the first session's credentials go stale, which is why it "worked on day one".

Two things confirm the proxy is not losing the data:

- Counting bytes **inside the proxy** shows it relays those six bytes faithfully — YouTube is withholding the media, not the proxy dropping it.
- The TizenBrew module version is unaffected, and both issue reporters say so. It runs on the genuine origin.

Worth noting for anyone who tries the obvious workaround: the origin cannot be faked from inside the page. `window.location` is `[LegacyUnforgeable]` in the HTML spec, so `Object.defineProperty(window, 'location', …)` throws. The origin has to actually be correct.

## The fix

Load the real `https://www.youtube.com/tv` and inject the userscript over the Chrome DevTools Protocol — the same mechanism TizenBrew's module loader uses (`service-nextgen/service/utils/debugger.js`), which is precisely why the module version never had this problem.

The service connects to the TV's own sdbd on `127.0.0.1:26101`, asks it to relaunch the UI app with remote debugging, attaches with `chrome-remote-interface`, arms the userscript via `Page.addScriptToEvaluateOnNewDocument` (falling back to `Runtime.evaluate` on `Runtime.executionContextCreated`), and navigates.

`Page.setBypassCSP` replaces the CSP header stripping the proxy used to do, which is the tradeoff described in [#74](https://github.com/reisxd/TizenTube/issues/74).

Two implementation notes that cost some time and may save yours:

- **`adbhost` does not work here.** It ignores AUTH, and it reads its socket in `'readable'` mode, so any `'data'` listener added for instrumentation never fires and it reports "no bytes received" while bytes are in fact arriving. This PR uses a small hand-rolled ADB framing client instead. Only `chrome-remote-interface` is added as a dependency.
- **`shell:0 debug` opens its stream and then goes silent if the target app is in the foreground.** Reproducible from a PC too: the same command times out at 30s with the app running and returns instantly from the home screen. So the UI app closes itself first and lets the service relaunch it. There is a loop-breaker in case the service is ever torn down along with the app.

## Fallback behaviour

The proxy is left exactly as it is and `index.html` falls back to it if the handover does not complete, so a TV that cannot make the loopback debug connection keeps today's behaviour rather than breaking. The user sees a plain loading screen; the diagnostic trace is only shown on failure.

## Requirements

This needs **developer mode on, with Host PC IP set to `127.0.0.1`**.

In practice that is a small ask: sideloading Standalone already requires developer mode, and TizenBrew requires this exact same setting — its `canLaunchInDebug` check gates on it, which is also where the "set Host PC IP to 127.0.0.1" advice in #563 came from. Anyone already running TizenTube or TizenBrew will have developer mode enabled. The only change is that it needs to stay on rather than being switched off after installing.

If the setting is not right, nothing breaks: the handover fails cleanly and the app falls back to the existing proxy behaviour.

For reference, the difference is visible at the protocol level — with a LAN IP configured, sdbd accepts the TCP connection and then closes it the moment CNXN is sent; at `127.0.0.1` it answers `CNXN banner="device::<model>::0"`.

I did not verify whether declaring the service `on_boot` could pre-arm debugging and make the restart invisible — plausible, but untested, so I am not claiming it.

## Testing

Verified on a Samsung QE77S90CATXXH (Tizen 9.0): the app shows a splash, restarts itself once, lands on the real youtube.com, and **video playback works**. Tested with this exact branch, which contains no other changes.