### PR TITLE
[EN, PL, DE] Localisation update icl. new strings 

### DIFF
--- a/mods/features/updater.js
+++ b/mods/features/updater.js
@@ -2,6 +2,7 @@
 
 import { buttonItem, showModal, showToast, overlayPanelItemListRenderer, scrollPaneRenderer, overlayMessageRenderer } from '../ui/ytUI.js';
 import { configRead } from '../config.js';
+import { t } from 'i18next';
 
 // If TizenTube is not running on Cobalt, do nothing
 // Add a timeout since reloading the home page while the updater pop up is shown causes the pop up to instantly disappear.
@@ -50,11 +51,11 @@ function checkForUpdates(showNoUpdateToast) {
 
             if (latestVersion !== currentAppVersion) {
                 console.info(`New version available: ${latestVersion} (current: ${currentAppVersion})`);
-                const msg = `Release Date: ${new Date(releaseDate * 1000).toLocaleString()}\n${release.body}`.replace(/#/g, '').replace(/\*/g, '').trim();
+                const msg = `${t('settings.options.updater.releaseDate', { date: new Date(releaseDate * 1000).toLocaleString() })}\n${release.body}`.replace(/#/g, '').replace(/\*/g, '').trim();
 
                 const buttons = [
                     buttonItem(
-                        { title: 'Update Now', subtitle: 'Click to download the latest version.' },
+                        { title: t('settings.options.updater.updateNow.title'), subtitle: t('settings.options.updater.updateNow.subtitle') },
                         { icon: 'DOWN_ARROW' },
                         [
                             {
@@ -71,7 +72,7 @@ function checkForUpdates(showNoUpdateToast) {
                         ]
                     ),
                     buttonItem(
-                        { title: 'Remind Me Later', subtitle: 'Check for updates later.' },
+                        { title: t('settings.options.updater.remindLater.title'), subtitle: t('settings.options.updater.remindLater.subtitle') },
                         { icon: 'SEARCH_HISTORY' },
                         [
                             {
@@ -95,8 +96,8 @@ function checkForUpdates(showNoUpdateToast) {
 
                 showModal(
                     {
-                        title: 'Update Available',
-                        subtitle: `A new version of TizenTube Cobalt is available: ${latestVersion}, current: ${currentAppVersion}`
+                        title: t('settings.options.updater.updateAvailable.title'),
+                        subtitle: t('settings.options.updater.updateAvailable.subtitle', { latestVersion, currentVersion: currentAppVersion })
                     },
                     overlayPanelItemListRenderer(buttons),
                     'tt-update-modal',
@@ -105,13 +106,13 @@ function checkForUpdates(showNoUpdateToast) {
             } else {
                 console.info('You are using the latest version of TizenTube.');
                 if (showNoUpdateToast) {
-                    showToast('TizenTube is up to date', `You are using the latest version (${currentAppVersion}) of TizenTube Cobalt.`, null);
+                    showToast(t('settings.options.updater.upToDate.title'), t('settings.options.updater.upToDate.subtitle', { version: currentAppVersion }), null);
                 }
             }
         })
         .catch(error => {
             console.error('Error fetching the latest release:', error);
-            showToast('TizenTube update check failed', 'Could not check for updates.', null);
+            showToast(t('settings.options.updater.checkFailed.title'), t('settings.options.updater.checkFailed.subtitle'), null);
         });
 }
 

--- a/mods/resolveCommand.js
+++ b/mods/resolveCommand.js
@@ -195,7 +195,7 @@ function customAction(action, parameters) {
             break;
         case 'UPDATE_DOWNLOAD':
             window.h5vcc.tizentube.InstallAppFromURL(parameters);
-            showToast('TizenTube Update', t('toasts.downloadingUpdate'));
+            showToast(t('settings.options.updater.downloading.title'), t('settings.options.updater.downloading.subtitle'));
             break;
         case 'SET_PLAYER_SPEED':
             const speed = Number(parameters);

--- a/mods/resolveCommand.js
+++ b/mods/resolveCommand.js
@@ -4,6 +4,7 @@ import modernUI, { optionShow } from './ui/settings.js';
 import { speedSettings } from './ui/speedUI.js';
 import { showToast, buttonItem } from './ui/ytUI.js';
 import checkForUpdates from './features/updater.js';
+import { t } from 'i18next';
 
 export default function resolveCommand(cmd, _) {
     // resolveCommand function is pretty OP, it can do from opening modals, changing client settings and way more.
@@ -79,7 +80,7 @@ export function patchResolveCommand() {
                     const items = cmd.openPopupAction.popup.overlaySectionRenderer.overlay.overlayTwoPanelRenderer.actionPanel.overlayPanelRenderer.content.overlayPanelItemListRenderer.items;
                     for (const item of items) {
                         if (item?.compactLinkRenderer?.icon?.iconType === 'SLOW_MOTION_VIDEO') {
-                            item.compactLinkRenderer.subtitle && (item.compactLinkRenderer.subtitle.simpleText = 'with TizenTube');
+                            item.compactLinkRenderer.subtitle && (item.compactLinkRenderer.subtitle.simpleText = t('player.withTizenTube'));
                             item.compactLinkRenderer.serviceEndpoint = {
                                 clickTrackingParams: "null",
                                 signalAction: {
@@ -94,7 +95,7 @@ export function patchResolveCommand() {
 
                     cmd.openPopupAction.popup.overlaySectionRenderer.overlay.overlayTwoPanelRenderer.actionPanel.overlayPanelRenderer.content.overlayPanelItemListRenderer.items.splice(2, 0,
                         buttonItem(
-                            { title: 'Mini Player' },
+                            { title: t('player.miniPlayer') },
                             { icon: 'CLEAR_COOKIES' }, [
                             {
                                 customAction: {
@@ -108,8 +109,8 @@ export function patchResolveCommand() {
                         window.h5vcc.tizentube.HasSystemFeature('android.software.picture_in_picture')) {
                         cmd.openPopupAction.popup.overlaySectionRenderer.overlay.overlayTwoPanelRenderer.actionPanel.overlayPanelRenderer.content.overlayPanelItemListRenderer.items.splice(3, 0,
                             buttonItem(
-                                { title: 'Picture in Picture' },
-                                { icon: 'PIP' }, [
+                                { title: t('player.pictureInPicture') },
+                                { icon: 'TV' }, [
                                 {
                                     customAction: {
                                         action: 'ENTER_PIP'
@@ -194,7 +195,7 @@ function customAction(action, parameters) {
             break;
         case 'UPDATE_DOWNLOAD':
             window.h5vcc.tizentube.InstallAppFromURL(parameters);
-            showToast('TizenTube Update', 'Downloading update, please wait...');
+            showToast('TizenTube Update', t('toasts.downloadingUpdate'));
             break;
         case 'SET_PLAYER_SPEED':
             const speed = Number(parameters);
@@ -211,11 +212,11 @@ function customAction(action, parameters) {
             break;
         case 'ADD_TO_QUEUE':
             window.queuedVideos.videos.push(parameters);
-            showToast('TizenTube', 'Video added to queue.');
+            showToast('TizenTube', t('toasts.videoAddedToQueue'));
             break;
         case 'CLEAR_QUEUE':
             window.queuedVideos.videos = [];
-            showToast('TizenTube', 'Video queue cleared.');
+            showToast('TizenTube', t('toasts.videoQueueCleared'));
             break;
         case 'CHECK_FOR_UPDATES':
             checkForUpdates(true);

--- a/mods/translations/resources/de.json
+++ b/mods/translations/resources/de.json
@@ -183,6 +183,31 @@
                 "options": {
                     "checkForUpdates": "Nach Updates suchen",
                     "checkForUpdatesOnStartup": "Beim Start nach Updates suchen"
+                },
+                "updateAvailable": {
+                    "title": "Update verfügbar",
+                    "subtitle": "Eine neue Version von TizenTube Cobalt ist verfügbar: {{latestVersion}}, installiert: {{currentVersion}}"
+                },
+                "releaseDate": "Veröffentlichungsdatum: {{date}}",
+                "updateNow": {
+                    "title": "Jetzt aktualisieren",
+                    "subtitle": "Klicken Sie hier, um die neueste Version herunterzuladen"
+                },
+                "remindLater": {
+                    "title": "Später daran erinnern",
+                    "subtitle": "Später nach Updates suchen."
+                },
+                "upToDate": {
+                    "title": "TizenTube ist auf dem neuesten Stand",
+                    "subtitle": "Sie verwenden die neueste Version ({{version}}) von TizenTube Cobalt."
+                },
+                "checkFailed": {
+                    "title": "Überprüfung auf TizenTube-Updates fehlgeschlagen",
+                    "subtitle": "Es konnten keine Updates gefunden werden."
+                },
+                "downloading": {
+                    "title": "TizenTube-Update",
+                    "subtitle": "Update wird heruntergeladen, bitte warten..."
                 }
             }
         },
@@ -239,7 +264,6 @@
         "withTizenTube": "mit TizenTube"
     },
     "toasts": {
-        "downloadingUpdate": "Update wird heruntergeladen, bitte warten...",
         "videoAddedToQueue": "Video wurde zur Warteschlange hinzugefügt",
         "videoQueueCleared": "Die Warteschlange wurde geleert."
     }

--- a/mods/translations/resources/de.json
+++ b/mods/translations/resources/de.json
@@ -75,9 +75,12 @@
                         "title": "Videoplayer-UI patchen",
                         "options": {
                             "enableVPUIPatching": "Videoplayer-UI-Patching aktivieren",
-                            "previousNextBtns": "Vorheriger-/Nächster-Buttons aktivieren",
+                            "previousNextBtns": "Zurück-/Weiter-Buttons aktivieren",
                             "showSuperThxBtn": "Super-Thanks-Button anzeigen",
-                            "showSpeedCtrlBtn": "Geschwindigkeitssteuerungs-Button anzeigen"
+                            "showAIAskBtn": "KI-Frage-Button anzeigen",
+                            "showSpeedCtrlBtn": "Geschwindigkeitssteuerungs-Button anzeigen",
+                            "addMPBtn": "Miniplayer-Schaltfläche anzeigen",
+                            "swapMPWithPIP": "Miniplayer-Schaltfläche durch PiP ersetzen"
                         }
                     },
                     "preferredVideoQuality": {
@@ -96,8 +99,16 @@
                     "afrPauseDuration": {
                         "title": "Pause bei automatischer Bildrate",
                         "subtitle": "Lege fest, wie lange (in Sekunden) das Video pausiert wird, wenn die Bildrate angepasst wird"
-                    }
+                    },
+                    "codecAny": "Beliebig",
+                    "qualityAuto": "Automatisch"
                 }
+            },
+            "time": {
+                "second": "{{count}} Sekunde",
+                "seconds": "{{count}} Sekunden",
+                "minute": "{{count}} Minute",
+                "minutes": "{{count}} Minuten"
             },
             "uiSettings": {
                 "title": "Benutzeroberflächen-Einstellungen",
@@ -136,7 +147,33 @@
                         "title": "Startseite beim Start",
                         "subtitle": "Wähle die Standardseite, die TizenTube beim Start öffnet"
                     },
-                    "sortSubscriptionsByAlphabet": "Abonnements alphabetisch sortieren"
+                    "categories": {
+                        "search": "Suchen",
+                        "home": "Startseite",
+                        "sports": "Sport",
+                        "news": "Nachrichten",
+                        "music": "Musik",
+                        "podcasts": "Podcasts",
+                        "moviesAndTv": "Filme",
+                        "live": "Live",
+                        "gaming": "Gaming",
+                        "subscriptions": "Abos",
+                        "library": "Mediathek",
+                        "more": "Mehr",
+                        "shorts": "Shorts",
+                        "searchResults": "Suchergebnisse"
+                    },
+                    "sortSubscriptionsByAlphabet": "Abonnements alphabetisch sortieren",
+                    "disableChannelsOnSidebar": "Kanäle in der Seitenleiste deaktivieren",
+                    "clock": {
+                        "title": "Uhr",
+                        "subtitle": "Die Uhr auf dem Bildschirm anzeigen",
+                        "options": {
+                            "enableClock": "Uhr aktivieren",
+                            "isClock12HourFormat": "12-Stunden-Format",
+                            "clockShowSeconds": "Sekunden anzeigen"
+                        }
+                    }
                 }
             },
             "updater": {
@@ -189,5 +226,21 @@
             "skip": "{{segment}} überspringen",
             "skipToHighlight": "Zum Highlight springen"
         }
+    },
+    "player": {
+        "playbackSpeed": {
+            "title": "Wiedergabegeschwindigkeit",
+            "button": "Geschwindigkeit"
+        },
+        "miniPlayer": "MiniPlayer",
+        "pictureInPicture": "Bild-in-Bild",	  
+        "previous": "Zurück",
+        "next": "Weiter",
+        "withTizenTube": "mit TizenTube"
+    },
+    "toasts": {
+        "downloadingUpdate": "Update wird heruntergeladen, bitte warten...",
+        "videoAddedToQueue": "Video wurde zur Warteschlange hinzugefügt",
+        "videoQueueCleared": "Die Warteschlange wurde geleert."
     }
 }

--- a/mods/translations/resources/de.json
+++ b/mods/translations/resources/de.json
@@ -6,7 +6,11 @@
         "options": {
             "socialMedia": {
                 "title": "Social-Media-Links",
-                "qrCodeScanMessage": "Du kannst die {{name}}-Seite besuchen, indem du den untenstehenden QR-Code scannst."
+                "qrCodeScanMessage": "Du kannst die {{name}}-Seite besuchen, indem du den untenstehenden QR-Code scannst.",
+                "announcements": "Anzeigen",
+                "group": "Gruppe",
+                "website": "Website",
+                "githubSponsors": "GitHub Sponsoren"
             },
             "adBlock": "Werbeblocker",
             "sponsorblock": {
@@ -225,7 +229,7 @@
                 "3": "2. Teile TizenTube mit anderen.",
                 "4": "Wenn du finanziell beitragen möchtest, kannst du spenden:",
                 "5": "- Buy Me A Coffee: https://www.buymeacoffee.com/reisxd (bevorzugt)",
-                "6": "- GitHub Sponsors: https://github.com/sponsors/reisxd"
+                "6": "- GitHub Sponsoren: https://github.com/sponsors/reisxd"
             }
         }
     },
@@ -255,7 +259,8 @@
     "player": {
         "playbackSpeed": {
             "title": "Wiedergabegeschwindigkeit",
-            "button": "Geschwindigkeit"
+            "button": "Geschwindigkeit",
+            "fixStuttering": "Ruckeln beheben (1.0001x)"
         },
         "miniPlayer": "MiniPlayer",
         "pictureInPicture": "Bild-in-Bild",	  

--- a/mods/translations/resources/en.json
+++ b/mods/translations/resources/en.json
@@ -183,6 +183,31 @@
                 "options": {
                     "checkForUpdates": "Check for updates",
                     "checkForUpdatesOnStartup": "Check for updates on startup"
+                },
+                "updateAvailable": {
+                    "title": "Update Available",
+                    "subtitle": "A new version of TizenTube Cobalt is available: {{latestVersion}}, current: {{currentVersion}}"
+                },
+                "releaseDate": "Release Date: {{date}}",
+                "updateNow": {
+                    "title": "Update Now",
+                    "subtitle": "Click to download the latest version."
+                },
+                "remindLater": {
+                    "title": "Remind Me Later",
+                    "subtitle": "Check for updates later."
+                },
+                "upToDate": {
+                    "title": "TizenTube is up to date",
+                    "subtitle": "You are using the latest version ({{version}}) of TizenTube Cobalt."
+                },
+                "checkFailed": {
+                    "title": "TizenTube update check failed",
+                    "subtitle": "Could not check for updates."
+                },
+                "downloading": {
+                    "title": "TizenTube Update",
+                    "subtitle": "Downloading update, please wait..."
                 }
             }
         },
@@ -239,7 +264,6 @@
         "withTizenTube": "with TizenTube"
     },
     "toasts": {
-        "downloadingUpdate": "Downloading update, please wait...",
         "videoAddedToQueue": "Video added to queue.",
         "videoQueueCleared": "Video queue cleared."
     }

--- a/mods/translations/resources/en.json
+++ b/mods/translations/resources/en.json
@@ -99,8 +99,16 @@
                     "afrPauseDuration": {
                         "title": "Auto Frame Rate Pause Duration",
                         "subtitle": "Set the duration (in seconds) to pause video playback when adjusting frame rate"
-                    }
+                    },
+                    "codecAny": "Any",
+                    "qualityAuto": "Auto"
                 }
+            },
+            "time": {
+                "second": "{{count}} second",
+                "seconds": "{{count}} seconds",
+                "minute": "{{count}} minute",
+                "minutes": "{{count}} minutes"
             },
             "uiSettings": {
                 "title": "User Interface Settings",
@@ -138,6 +146,22 @@
                     "launchToOnStartup": {
                         "title": "Launch To on Startup",
                         "subtitle": "Choose the default page TizenTube opens to on startup"
+                    },
+                    "categories": {
+                        "search": "Search",
+                        "home": "Home",
+                        "sports": "Sports",
+                        "news": "News",
+                        "music": "Music",
+                        "podcasts": "Podcasts",
+                        "moviesAndTv": "Movies & TV",
+                        "live": "Live",
+                        "gaming": "Gaming",
+                        "subscriptions": "Subscriptions",
+                        "library": "Library",
+                        "more": "More",
+                        "shorts": "Shorts",
+                        "searchResults": "Search Results"
                     },
                     "sortSubscriptionsByAlphabet": "Sort Subscriptions Alphabetically",
                     "disableChannelsOnSidebar": "Disable Channels on Sidebar",
@@ -202,5 +226,21 @@
             "skip": "Skip {{segment}}",
             "skipToHighlight": "Skip to highlight"
         }
+    },
+    "player": {
+        "playbackSpeed": {
+            "title": "Playback Speed",
+            "button": "Speed Controls"
+        },
+        "miniPlayer": "Mini Player",
+        "pictureInPicture": "Picture in Picture",
+        "previous": "Previous",
+        "next": "Next",
+        "withTizenTube": "with TizenTube"
+    },
+    "toasts": {
+        "downloadingUpdate": "Downloading update, please wait...",
+        "videoAddedToQueue": "Video added to queue.",
+        "videoQueueCleared": "Video queue cleared."
     }
 }

--- a/mods/translations/resources/en.json
+++ b/mods/translations/resources/en.json
@@ -6,7 +6,11 @@
         "options": {
             "socialMedia": {
                 "title": "Social Media Links",
-                "qrCodeScanMessage": "You can visit the {{name}} page by scanning the QR code below."
+                "qrCodeScanMessage": "You can visit the {{name}} page by scanning the QR code below.",
+                "announcements": "Announcements",
+                "group": "Group",
+                "website": "Website",
+                "githubSponsors": "GitHub Sponsors"
             },
             "adBlock": "Ad Block",
             "sponsorblock": {
@@ -255,7 +259,8 @@
     "player": {
         "playbackSpeed": {
             "title": "Playback Speed",
-            "button": "Speed Controls"
+            "button": "Speed Controls",
+            "fixStuttering": "Fix stuttering (1.0001x)"
         },
         "miniPlayer": "Mini Player",
         "pictureInPicture": "Picture in Picture",

--- a/mods/translations/resources/pl.json
+++ b/mods/translations/resources/pl.json
@@ -183,6 +183,31 @@
                 "options": {
                     "checkForUpdates": "Sprawdź dostępność aktualizacji",
                     "checkForUpdatesOnStartup": "Sprawdź aktualizacje przy uruchomieniu"
+                },
+                "updateAvailable": {
+					"title": "Dostępna aktualizacja",
+                    "subtitle": "Nowa wersja TizenTube Cobalt jest dostępna: {{latestVersion}}, zainstalowana: {{currentVersion}}"
+                },
+                "releaseDate": "Wydana: {{date}}",
+                "updateNow": {
+                    "title": "Aktualizuj teraz",
+                    "subtitle": "Naciśnij, aby pobrać najnowszą wersję"
+                },
+                "remindLater": {
+                    "title": "Przypomnij mi później",
+                    "subtitle": "Sprawdź dostępność aktualizacji później"
+                },
+                "upToDate": {
+                    "title": "TizenTube jest aktualne",
+                    "subtitle": "Używasz już najnowszej wersji ({{version}}) TizenTube Cobalt."
+                },
+                "checkFailed": {
+                    "title": "TizenTube update check failed",
+                    "subtitle": "Could not check for updates." 
+                },
+                "downloading": {
+                    "title": "Aktualizacja TizenTube",
+                    "subtitle": "Pobieranie aktualizacji, proszę czekać..."
                 }
             }
         },
@@ -239,7 +264,6 @@
         "withTizenTube": "Za pomocą TizenTube"
     },
     "toasts": {
-        "downloadingUpdate": "Pobieranie aktualizacji, proszę czekać...",
         "videoAddedToQueue": "Dodano film do kolejki",
         "videoQueueCleared": "Kolejka została wyczyszczona."
     }

--- a/mods/translations/resources/pl.json
+++ b/mods/translations/resources/pl.json
@@ -23,7 +23,7 @@
                         "selfpromo": "Pomiń autopromocję",
                         "preview": "Pomiń zapowiedzi/podsumowania",
                         "filler": "Pomiń wypełniacze/żarty",
-                        "music_offtopic": "Pomiń fragmenty niemuzczne",
+                        "music_offtopic": "Pomiń fragmenty niemuzyczne",
                         "highlights": "Włącz wyróżnione momenty"
                     },
                     "showSBToasts": "Pokaż powiadomienia SponsorBlock"
@@ -40,24 +40,24 @@
                 "title": "Różne ustawienia",
                 "options": {
                     "endScreenCards": "Ukryj karty końcowe",
-                    "youThereRenderer": "Włącz okienko „Czy nadal oglądasz?”",
-                    "paidPromoOverlay": "Włącz nakładkę „Zawiera płatną promocję”",
+                    "youThereRenderer": "Powiadomienie o bezczynności",
+                    "paidPromoOverlay": "Włącz informację o płatnej promocji",
                     "whosWatching": {
-                        "title": "Menu „Kto ogląda”",
+                        "title": "Ekran „Kto ogląda”",
                         "options": {
-                            "enableWW": "Włącz menu „Kto ogląda”",
-                            "permaEnableWW": "Na stałe włącz menu „Kto ogląda”",
-                            "enableWWOnExit": "Włącz menu „Kto ogląda” przy wyjściu z aplikacji"
+                            "enableWW": "Włącz ekran wyboru profilu",
+                            "permaEnableWW": "Zawsze pokazuj wybór profilu",
+                            "enableWWOnExit": "Pytaj o profil przy wyjściu z aplikacji"
                         }
                     },
-                    "fixUI": "Napraw interfejs aplikacji",
-                    "hqThumbnails": "Włącz miniaturki wysokiej jakości",
-                    "longPress": "Włącz funkcje długiego naciśnięcia",
+                    "fixUI": "Napraw interfejs",
+                    "hqThumbnails": "Wysoka jakość miniaturek",
+                    "longPress": "Włącz funkcje przytrzymania",
                     "shorts": "Włącz Shorts",
-                    "videoPreviews": "Włącz podgląd wideo",
-                    "ttWelcomeMsg": "Pokazuj wiadomość powitalną TT",
-                    "guestSignInReminder": "Pokaż przypomnienie o logowaniu dla gości",
-                    "reloadHomeOnStartup": "Przeładuj ekran główny przy starcie"
+                    "videoPreviews": "Włącz podgląd filmu",
+                    "ttWelcomeMsg": "Pokaż powitanie TT",
+                    "guestSignInReminder": "Przypomnienie o zalogowaniu się dla gości",
+                    "reloadHomeOnStartup": "Odśwież stronę główną przy starcie"
                 }
             },
             "subtitles": {
@@ -72,14 +72,15 @@
                 "subtitle": "Dostosuj funkcje odtwarzacza wideo",
                 "options": {
                     "patching": {
-                        "title": "Modyfikacja interfejsu odtwarzacza",
+                        "title": "Modyfikacje interfejsu odtwarzacza",
                         "options": {
                             "enableVPUIPatching": "Włącz modyfikację interfejsu odtwarzacza",
                             "previousNextBtns": "Włącz przyciski Poprzedni i Następny",
                             "showSuperThxBtn": "Pokaż przycisk Super Podziękowania",
+							"showAIAskBtn": "Pokaż przycisk Zapytaj",
                             "showSpeedCtrlBtn": "Pokaż przycisk kontroli prędkości",
                             "addMPBtn": "Pokaż przycisk miniodtwarzacza",
-                            "swapMPWithPIP": "Zamień przycisk miniodtwarzacza z PiP"
+                            "swapMPWithPIP": "Zamień miniodtwarzacz na PiP"
                         }
                     },
                     "preferredVideoQuality": {
@@ -98,22 +99,30 @@
                     "afrPauseDuration": {
                         "title": "Czas pauzy przy automatycznej zmianie klatek",
                         "subtitle": "Ustaw czas trwania (w sekundach) pauzy odtwarzania wideo podczas dostosowywania liczby klatek na sekundę"
-                    }
+                    },
+                    "codecAny": "Dowolny",
+                    "qualityAuto": "Automatyczna"
                 }
+            },
+            "time": {
+                "second": "{{count}} s",
+                "seconds": "{{count}} s",
+                "minute": "{{count}} min",
+                "minutes": "{{count}} min"
             },
             "uiSettings": {
                 "title": "Ustawienia interfejsu użytkownika",
-                "subtitle": "Dostosuj interfejs użytkownika do swoich upodobań",
+                "subtitle": "Dostosuj interfejs użytkownika do swoich preferencji",
                 "options": {
                     "hideWatchedVideos": {
                         "title": "Ukryj obejrzane filmy",
                         "options": {
                             "enableHideWatchedVideos": "Włącz ukrywanie obejrzanych filmów",
                             "watchedVideosThreshold": {
-                                "title": "Próg obejrzanych filmów",
+                                "title": "Próg obejrzenia",
                                 "subtitle": "Ustaw próg procentowy dla ukrywania obejrzanych filmów"
                             },
-                            "setPagesToHideWatchedVideos": "Ustaw strony, na których mają być ukrywane obejrzane filmy"
+                            "setPagesToHideWatchedVideos": "Ukrywaj obejrzane na stronach"
                         }
                     },
                     "screenDimming": {
@@ -122,7 +131,7 @@
                             "enableScreenDimming": "Włącz przyciemnianie ekranu",
                             "dimmingTimeout": {
                                 "title": "Czas do przyciemnienia",
-                                "subtitle": "Ustaw czas bezczynności (w sekundach) przed przyciemnieniem ekranu"
+                                "subtitle": "Ustaw czas bezczynności przed przyciemnieniem ekranu"
                             },
                             "dimmingOpacity": {
                                 "title": "Krycie przyciemnienia",
@@ -132,12 +141,28 @@
                     },
                     "disableSidebarContents": {
                         "title": "Wyłącz zawartość paska bocznego",
-                        "subtitle": "Wybierz elementy do wyłączenia"
+                        "subtitle": "Wybierz elementy do ukrycia"
                     },
                     "launchToOnStartup": {
                         "title": "Strona startowa",
                         "subtitle": "Wybierz domyślną stronę, która otwiera się po uruchomieniu TizenTube"
                     },
+                    "categories": {
+                        "search": "Szukaj",
+                        "home": "Główna",
+                        "sports": "Sport",
+                        "news": "Wiadomości",
+                        "music": "Muzyka",
+                        "podcasts": "Podcasty",
+                        "moviesAndTv": "Filmy",
+                        "live": "Na żywo",
+                        "gaming": "Gry",
+                        "subscriptions": "Subskrypcje",
+                        "library": "Biblioteka",
+                        "more": "Więcej",
+                        "shorts": "Shorts",
+                        "searchResults": "Wyniki wyszukiwania"
+                    }, 
                     "sortSubscriptionsByAlphabet": "Sortuj subskrypcje alfabetycznie",
                     "disableChannelsOnSidebar": "Wyłącz kanały na pasku bocznym",
                     "clock": {
@@ -145,7 +170,7 @@
                         "subtitle": "Wyświetlaj zegar na ekranie",
                         "options": {
                             "enableClock": "Włącz zegar",
-                            "isClock12HourFormat": "Użyj formatu 12-godzinnego",
+                            "isClock12HourFormat": "Format 12-godzinny",
                             "clockShowSeconds": "Pokaż sekundy"
                         }
                     }
@@ -154,7 +179,7 @@
             "updater": {
                 "title": "Aktualizacje TizenTube Cobalt",
                 "menuSubtitle": "Zarządzaj aktualizacjami TizenTube Cobalt",
-                "versionSubtitle": "Aktualna wersja: {{version}}",
+                "versionSubtitle": "Zainstalowana wersja: {{version}}",
                 "options": {
                     "checkForUpdates": "Sprawdź dostępność aktualizacji",
                     "checkForUpdatesOnStartup": "Sprawdź aktualizacje przy uruchomieniu"
@@ -192,14 +217,30 @@
             "selfpromo": "autopromocja",
             "preview": "podsumowanie lub zapowiedź",
             "filler": "wypełniacz",
-            "music_offtopic": "część niemuzczna",
+            "music_offtopic": "część niemuzyczna",
             "poi_highlight": "wyróżniony moment"
         },
         "toasts": {
             "skipping": "Pomijanie: {{segment}}",
             "notSkipping": "Nie pominięto: {{segment}} (pominięto {{count}} razy)",
             "skip": "Pomiń: {{segment}}",
-            "skipToHighlight": "Przejdź do wyróżnionego momentu"
+            "skipToHighlight": "Do wyróżnionego momentu"
         }
+    },
+    "player": {
+        "playbackSpeed": {
+            "title": "Prędkość odtwarzania",
+            "button": "Prędkość"
+        },
+        "miniPlayer": "Miniodtwarzacz",
+        "pictureInPicture": "Obraz w obrazie (PiP)",
+        "previous": "Poprzedni",
+        "next": "Następny",
+        "withTizenTube": "Za pomocą TizenTube"
+    },
+    "toasts": {
+        "downloadingUpdate": "Pobieranie aktualizacji, proszę czekać...",
+        "videoAddedToQueue": "Dodano film do kolejki",
+        "videoQueueCleared": "Kolejka została wyczyszczona."
     }
 }

--- a/mods/translations/resources/pl.json
+++ b/mods/translations/resources/pl.json
@@ -6,7 +6,11 @@
         "options": {
             "socialMedia": {
                 "title": "Linki do mediów społecznościowych",
-                "qrCodeScanMessage": "Możesz odwiedzić stronę {{name}}, skanując kod QR."
+                "qrCodeScanMessage": "Możesz odwiedzić stronę {{name}}, skanując poniższy kod QR.",
+                "announcements": "Ogłoszenia",
+                "group": "Grupa",
+                "website": "Strona internetowa",
+                "githubSponsors": "GitHub Sponsors"
             },
             "adBlock": "Blokada reklam",
             "sponsorblock": {
@@ -225,7 +229,7 @@
                 "3": "2. Poleć TizenTube znajomym.",
                 "4": "Jeśli chcesz wesprzeć projekt finansowo, możesz przekazać darowiznę:",
                 "5": "- Buy Me A Coffee: https://www.buymeacoffee.com/reisxd (Preferowane)",
-                "6": "- Sponsorzy GitHub: https://github.com/sponsors/reisxd"
+                "6": "- GitHub Sponsors: https://github.com/sponsors/reisxd"
             }
         }
     },
@@ -249,13 +253,14 @@
             "skipping": "Pomijanie: {{segment}}",
             "notSkipping": "Nie pominięto: {{segment}} (pominięto {{count}} razy)",
             "skip": "Pomiń: {{segment}}",
-            "skipToHighlight": "Do wyróżnionego momentu"
+            "skipToHighlight": "Wyróżniony moment"
         }
     },
     "player": {
         "playbackSpeed": {
-            "title": "Prędkość odtwarzania",
-            "button": "Prędkość"
+            "title": "Szybkość odtwarzania",
+            "button": "Szybkość",
+            "fixStuttering": "Napraw zacinanie się (1.0001x)"
         },
         "miniPlayer": "Miniodtwarzacz",
         "pictureInPicture": "Obraz w obrazie (PiP)",

--- a/mods/ui/customUI.js
+++ b/mods/ui/customUI.js
@@ -3,6 +3,7 @@
 import { extractAssignedFunctions } from "../utils/ASTParser.js";
 import { configRead } from "../config.js";
 import { ButtonRenderer } from "./ytUI.js";
+import { t } from 'i18next';
 
 function applyPatches() {
     if (!window._yttv) return setTimeout(applyPatches, 250);
@@ -49,7 +50,7 @@ function applyPatches() {
             "button": {
                 "buttonRenderer": ButtonRenderer(
                     false,
-                    configRead('enableSwapMPWithPIP') ? 'Picture in Picture' : 'Mini Player',
+                    configRead('enableSwapMPWithPIP') ? t('player.pictureInPicture') : t('player.miniPlayer'),
                     'CLEAR_COOKIES',
                     {
                         customAction: {
@@ -107,7 +108,7 @@ function applyPatches() {
                     button: {
                         buttonRenderer: ButtonRenderer(
                             false,
-                            "Speed Controls",
+                            t('player.playbackSpeed.button'),
                             'SLOW_MOTION_VIDEO',
                             {
                                 customAction:
@@ -147,7 +148,7 @@ function applyPatches() {
             inst[previousButtonName] = function () {
                 return ButtonRenderer(
                     false,
-                    'Previous',
+                    t('player.previous'),
                     'SKIP_PREVIOUS',
                     {
                         signalAction: {
@@ -160,7 +161,7 @@ function applyPatches() {
             inst[nextButtonName] = function () {
                 return ButtonRenderer(
                     false,
-                    'Next',
+                    t('player.next'),
                     'SKIP_NEXT',
                     {
                         signalAction: {

--- a/mods/ui/settings.js
+++ b/mods/ui/settings.js
@@ -387,7 +387,7 @@ export default function modernUI(update, parameters) {
                     options:
                         ['Auto', '2160p', '1440p', '1080p', '720p', '480p', '360p', '240p', '144p'].map((quality) => {
                             return {
-                                name: quality,
+                                name: quality === 'Auto' ? t('settings.options.videoPlayer.options.qualityAuto') : quality,
                                 key: 'preferredVideoQuality',
                                 value: quality.toLowerCase()
                             }
@@ -422,7 +422,7 @@ export default function modernUI(update, parameters) {
                     },
                     options: ['any', 'vp9', 'av01', 'avc1'].map((codec) => {
                         return {
-                            name: codec === 'any' ? 'Any' : codec.toUpperCase(),
+                            name: codec === 'any' ? t('settings.options.videoPlayer.options.codecAny') : codec.toUpperCase(),
                             key: 'preferredVideoCodec',
                             value: codec
                         }
@@ -444,7 +444,7 @@ export default function modernUI(update, parameters) {
                     },
                     options: [0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5].map((seconds) => {
                         return {
-                            name: `${seconds} seconds`,
+                            name: t(seconds === 1 ? 'settings.options.time.second' : 'settings.options.time.seconds', { count: seconds }),                            
                             key: 'autoFrameRatePauseVideoFor',
                             value: seconds * 1000
                         }
@@ -495,31 +495,31 @@ export default function modernUI(update, parameters) {
                             menuId: 'tt-hide-watched-videos-pages',
                             options: [
                                 {
-                                    name: 'Search Results',
+                                    name: t('settings.options.uiSettings.options.categories.searchResults'),
                                     value: 'search'
                                 },
                                 {
-                                    name: 'Home',
+                                    name: t('settings.options.uiSettings.options.categories.home'),
                                     value: 'home'
                                 },
                                 {
-                                    name: 'Music',
+                                    name: t('settings.options.uiSettings.options.categories.music'),
                                     value: 'music'
                                 },
                                 {
-                                    name: 'Gaming',
+                                    name: t('settings.options.uiSettings.options.categories.gaming'),
                                     value: 'gaming'
                                 },
                                 {
-                                    name: 'Subscriptions',
+                                    name: t('settings.options.uiSettings.options.categories.subscriptions'),
                                     value: 'subscriptions'
                                 },
                                 {
-                                    name: 'Library',
+                                    name: t('settings.options.uiSettings.options.categories.library'),
                                     value: 'library'
                                 },
                                 {
-                                    name: 'More',
+                                    name: t('settings.options.uiSettings.options.categories.more'),
                                     value: 'more'
                                 }
                             ]
@@ -547,7 +547,7 @@ export default function modernUI(update, parameters) {
                                 subtitle: t('settings.options.uiSettings.options.screenDimming.options.dimmingTimeout.subtitle')
                             },
                             options: [10, 20, 30, 60, 120, 180, 240, 300].map((seconds) => {
-                                const title = seconds >= 60 ? `${seconds / 60} minute${seconds / 60 > 1 ? 's' : ''}` : `${seconds} seconds`;
+                                const title = seconds >= 60 ? t(`settings.options.time.minute${seconds / 60 > 1 ? 's' : ''}`, { count: seconds / 60 }) : t('settings.options.time.seconds', { count: seconds });
                                 return {
                                     name: title,
                                     key: 'dimmingTimeout',
@@ -586,67 +586,67 @@ export default function modernUI(update, parameters) {
                     },
                     options: [
                         {
-                            name: 'Search',
+                            name: t('settings.options.uiSettings.options.categories.search'),
                             icon: 'SEARCH',
                             value: 'SEARCH'
                         },
                         {
-                            name: 'Home',
+                            name: t('settings.options.uiSettings.options.categories.home'),
                             icon: 'WHAT_TO_WATCH',
                             value: 'WHAT_TO_WATCH'
                         },
                         {
-                            name: 'Sports',
+                            name: t('settings.options.uiSettings.options.categories.sports'),
                             icon: 'TROPHY',
                             value: 'TROPHY'
                         },
                         {
-                            name: 'News',
+                            name: t('settings.options.uiSettings.options.categories.news'),
                             icon: 'NEWS',
                             value: 'NEWS'
                         },
                         {
-                            name: 'Music',
+                            name: t('settings.options.uiSettings.options.categories.music'),
                             icon: 'YOUTUBE_MUSIC',
                             value: 'YOUTUBE_MUSIC'
                         },
                         {
-                            name: 'Podcasts',
+                            name: t('settings.options.uiSettings.options.categories.podcasts'),
                             icon: 'BROADCAST',
                             value: 'BROADCAST'
                         },
                         {
-                            name: 'Movies & TV',
+                            name: t('settings.options.uiSettings.options.categories.moviesAndTv'),
                             icon: 'CLAPPERBOARD',
                             value: 'CLAPPERBOARD'
                         },
                         {
-                            name: 'Live',
+                            name: t('settings.options.uiSettings.options.categories.live'),
                             icon: 'LIVE',
                             value: 'LIVE'
                         },
                         {
-                            name: 'Gaming',
+                            name: t('settings.options.uiSettings.options.categories.gaming'),
                             icon: 'GAMING',
                             value: 'GAMING'
                         },
                         {
-                            name: 'Subscriptions',
+                            name: t('settings.options.uiSettings.options.categories.subscriptions'),
                             icon: 'SUBSCRIPTIONS',
                             value: 'SUBSCRIPTIONS'
                         },
                         {
-                            name: 'Library',
+                            name: t('settings.options.uiSettings.options.categories.library'),
                             icon: 'TAB_LIBRARY',
                             value: 'TAB_LIBRARY'
                         },
                         {
-                            name: 'More',
+                            name: t('settings.options.uiSettings.options.categories.more'),
                             icon: 'TAB_MORE',
                             value: 'TAB_MORE'
                         },
                         {
-                            name: 'Shorts',
+                            name: t('settings.options.uiSettings.options.categories.shorts'),
                             icon: 'YOUTUBE_SHORTS_FILL_24',
                             value: 'YOUTUBE_SHORTS_FILL_24'
                         }
@@ -663,7 +663,7 @@ export default function modernUI(update, parameters) {
                     },
                     options: [
                         {
-                            name: 'Search',
+                            name: t('settings.options.uiSettings.options.categories.search'),
                             icon: 'SEARCH',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -671,7 +671,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Home',
+                            name: t('settings.options.uiSettings.options.categories.home'),
                             icon: 'WHAT_TO_WATCH',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -679,7 +679,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Sports',
+                            name: t('settings.options.uiSettings.options.categories.sports'),
                             icon: 'TROPHY',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -687,7 +687,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'News',
+                            name: t('settings.options.uiSettings.options.categories.news'),
                             icon: 'NEWS',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -695,7 +695,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Music',
+                            name: t('settings.options.uiSettings.options.categories.music'),
                             icon: 'YOUTUBE_MUSIC',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -703,7 +703,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Podcasts',
+                            name: t('settings.options.uiSettings.options.categories.podcasts'),
                             icon: 'BROADCAST',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -711,7 +711,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Movies & TV',
+                            name: t('settings.options.uiSettings.options.categories.moviesAndTv'),
                             icon: 'CLAPPERBOARD',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -719,7 +719,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Gaming',
+                            name: t('settings.options.uiSettings.options.categories.gaming'),
                             icon: 'GAMING',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -727,7 +727,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Live',
+                            name: t('settings.options.uiSettings.options.categories.live'),
                             icon: 'LIVE',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -735,7 +735,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Subscriptions',
+                            name: t('settings.options.uiSettings.options.categories.subscriptions'),
                             icon: 'SUBSCRIPTIONS',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -743,7 +743,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'Library',
+                            name: t('settings.options.uiSettings.options.categories.library'),
                             icon: 'TAB_LIBRARY',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -751,7 +751,7 @@ export default function modernUI(update, parameters) {
                             })
                         },
                         {
-                            name: 'More',
+                            name: t('settings.options.uiSettings.options.categories.more'),
                             icon: 'TAB_MORE',
                             key: 'launchToOnStartup',
                             value: JSON.stringify({
@@ -1047,5 +1047,5 @@ export function optionShow(parameters, update) {
         }
     }
 
-    showModal(parameters.menuHeader ? parameters.menuHeader : 'TizenTube Settings', overlayPanelItemListRenderer(buttons, parameters.selectedIndex), parameters.menuId || 'tt-settings-options', update);
+    showModal(parameters.menuHeader ? parameters.menuHeader : t('settings.ttSettings.title'), overlayPanelItemListRenderer(buttons, parameters.selectedIndex), parameters.menuId || 'tt-settings-options', update);
 }

--- a/mods/ui/settings.js
+++ b/mods/ui/settings.js
@@ -43,15 +43,15 @@ export default function modernUI(update, parameters) {
                     link: 'https://discord.gg/m2P7v8Y2qR',
                 },
                 {
-                    name: 'Telegram (Announcements)',
+                    name: `Telegram (${t('settings.options.socialMedia.announcements')})`,
                     link: 'https://t.me/tizentubecobaltofficial',
                 },
                 {
-                    name: 'Telegram (Group)',
+                    name: `Telegram (${t('settings.options.socialMedia.group')})`,
                     link: 'https://t.me/tizentubeofficial',
                 },
                 {
-                    name: 'Website',
+                    name: t('settings.options.socialMedia.website'),
                     link: 'https://tizentube.6513006.xyz',
                 },
                 {
@@ -59,8 +59,8 @@ export default function modernUI(update, parameters) {
                     link: 'https://www.buymeacoffee.com/reisxd',
                 },
                 {
-                    name: 'GitHub Sponsors',
-                    link: 'https:///github.com/sponsors/reisxd',
+                    name: t('settings.options.socialMedia.githubSponsors'),
+                    link: 'https://github.com/sponsors/reisxd',
                 }
             ].map((option) => {
                 if (!qrcodes[option.name]) {

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -1,5 +1,6 @@
 import { configRead } from '../config.js';
 import { showModal, buttonItem, overlayPanelItemListRenderer } from './ytUI.js';
+import { t } from 'i18next';
 
 const interval = setInterval(() => {
     const videoElement = document.querySelector('video');
@@ -110,7 +111,7 @@ function speedSettings() {
         )
     );
 
-    showModal('Playback Speed', overlayPanelItemListRenderer(buttons, selectedIndex), 'tt-speed');
+    showModal(t('player.playbackSpeed.title'), overlayPanelItemListRenderer(buttons, selectedIndex), 'tt-speed');
 }
 
 export {

--- a/mods/ui/speedUI.js
+++ b/mods/ui/speedUI.js
@@ -81,7 +81,7 @@ function speedSettings() {
 
     buttons.push(
         buttonItem(
-            { title: `Fix stuttering (1.0001x)` },
+            { title: t('player.playbackSpeed.fixStuttering') },
             null,
             [
                 {


### PR DESCRIPTION
## Localisation update: player, toast messages and settings menus

### Changes:
- Fixes missing PiP icon
- ~~27~~ 47 new strings, translations for player ui mods, the updater and misc items
- Rewrites and updates Polish to be more concise and natural
- Updates German to include newer strings and the newly added ones

### Tested on:
- Android 11 on Nvidia Shield TV Pro
- Windows 11 on Chrome 150

### Preview (Chrome on Windows)
<img width="1920" height="1080" alt="Zrzut ekranu 2026-08-03 230558" src="https://github.com/user-attachments/assets/04234656-d71a-4d4a-83e3-84963d364fa2" />
<img width="1920" height="1080" alt="Zrzut ekranu 2026-08-03 225833" src="https://github.com/user-attachments/assets/c5e08c00-2d80-466a-b524-cf8466fe8543" />





## Newly added strings

**settings.options.socialMedia**
`announcements`, `group`, `website`, `githubSponsors`

**settings.options.videoPlayer.options**
`codecAny`, `qualityAuto`

**settings.options.uiSettings.options.categories**
`search`, `home`, `sports`, `news`, `music`, `podcasts`, `moviesAndTv`, `live`, `gaming`, `subscriptions`, `library`, `more`, `shorts`, `searchResults`

**settings.options.updater**
`updateAvailable.title`, `updateAvailable.subtitle`, `releaseDate`, `updateNow.title`, `updateNow.subtitle`, `remindLater.title`, `remindLater.subtitle`, `upToDate.title`, `upToDate.subtitle`, `checkFailed.title`, `checkFailed.subtitle`, `downloading.title`, `downloading.subtitle`

**settings.options.time**
`second`, `seconds`, `minute`, `minutes`

**player**
`playbackSpeed.title`, `playbackSpeed.button`, `playbackSpeed.fixStuttering`, `miniPlayer`, `pictureInPicture`, `previous`, `next`, `withTizenTube`

**toasts**
`videoAddedToQueue`, `videoQueueCleared`