### PR TITLE
fix: long-press menus for Watch Later

### DIFF
--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -126,6 +126,10 @@ JSON.parse = function () {
       r.continuationContents.horizontalListContinuation.items = hideVideo(r.continuationContents.horizontalListContinuation.items);
     }
 
+    if (r?.continuationContents?.gridContinuation?.items) {
+      addLongPress(r.continuationContents.gridContinuation.items);
+    }
+
     if (r?.contents?.tvBrowseRenderer?.content?.tvSecondaryNavRenderer?.sections) {
       for (let i = 0; i < r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections.length; i++) {
         const section = r.contents.tvBrowseRenderer.content.tvSecondaryNavRenderer.sections[i].tvSecondaryNavSectionRenderer;
@@ -141,11 +145,15 @@ JSON.parse = function () {
 
         for (let j = 0; j < section.tabs.length; j++) {
           const tab = section.tabs[j];
-          if (tab.tabRenderer.content?.tvSurfaceContentRenderer?.content?.sectionListRenderer?.contents) {
+          const content = tab.tabRenderer.content?.tvSurfaceContentRenderer?.content;
+          if (content?.sectionListRenderer?.contents) {
             const index = section.tabs.indexOf(tab);
-            const clone = tab.tabRenderer.content.tvSurfaceContentRenderer.content.sectionListRenderer.contents;
+            const clone = content.sectionListRenderer.contents;
             processShelves(clone);
             section.tabs[index].tabRenderer.content.tvSurfaceContentRenderer.content.sectionListRenderer.contents = clone;
+          }
+          if (content?.gridRenderer?.items) {
+            addLongPress(content.gridRenderer.items);
           }
         }
       }

--- a/mods/features/adblock.js
+++ b/mods/features/adblock.js
@@ -86,6 +86,13 @@ JSON.parse = function () {
       processShelves(r.contents.tvBrowseRenderer.content.tvSurfaceContentRenderer.content.sectionListRenderer.contents);
     }
 
+    if (
+      r?.contents?.tvBrowseRenderer?.content?.tvSurfaceContentRenderer?.content
+        ?.gridRenderer?.items
+    ) {
+      addLongPress(r.contents.tvBrowseRenderer.content.tvSurfaceContentRenderer.content.gridRenderer.items);
+    }
+
     if (r.endscreen && configRead('enableHideEndScreenCards')) {
       r.endscreen = null;
     }

--- a/mods/ui/settings.js
+++ b/mods/ui/settings.js
@@ -966,7 +966,7 @@ export function optionShow(parameters, update) {
                 continue;
             }
             const isRadioChoice = option.key !== null && option.key !== undefined;
-            const currentVal = configRead(isRadioChoice ? option.key : option.value);
+            const currentVal = option.value === null ? undefined : configRead(isRadioChoice ? option.key : option.value);
             buttons.push(
                 buttonItem(
                     { title: option.name, subtitle: option.subtitle },

--- a/mods/ui/ytUI.js
+++ b/mods/ui/ytUI.js
@@ -191,7 +191,7 @@ function longPressData(data) {
     const isWatchLaterItem = data.watchEndpointData.playlistId === 'WL';
     const watchLaterAction = isWatchLaterItem ? {
         removedVideoId: data.videoId,
-        action: 'ACTION_REMOVE_VIDEO'
+        action: 'ACTION_REMOVE_VIDEO_BY_VIDEO_ID'
     } : {
         addedVideoId: data.videoId,
         action: 'ACTION_ADD_VIDEO'
@@ -219,6 +219,12 @@ function longPressData(data) {
                         }),
                         MenuServiceItemRenderer(isWatchLaterItem ? 'Remove from Watch Later' : 'Save to Watch Later', {
                             clickTrackingParams: null,
+                            commandMetadata: {
+                                webCommandMetadata: {
+                                    sendPost: true,
+                                    apiUrl: '/youtubei/v1/browse/edit_playlist'
+                                }
+                            },
                             playlistEditEndpoint: {
                                 playlistId: 'WL',
                                 actions: [watchLaterAction]

--- a/mods/ui/ytUI.js
+++ b/mods/ui/ytUI.js
@@ -188,6 +188,15 @@ function timelyAction(text, icon, command, triggerTimeMs, timeoutMs) {
 }
 
 function longPressData(data) {
+    const isWatchLaterItem = data.watchEndpointData.playlistId === 'WL';
+    const watchLaterAction = isWatchLaterItem ? {
+        removedVideoId: data.videoId,
+        action: 'ACTION_REMOVE_VIDEO'
+    } : {
+        addedVideoId: data.videoId,
+        action: 'ACTION_ADD_VIDEO'
+    };
+
     return {
         clickTrackingParams: null,
         showMenuCommand: {
@@ -208,16 +217,11 @@ function longPressData(data) {
                             clickTrackingParams: null,
                             watchEndpoint: data.watchEndpointData
                         }),
-                        MenuServiceItemRenderer('Save to Watch Later', {
+                        MenuServiceItemRenderer(isWatchLaterItem ? 'Remove from Watch Later' : 'Save to Watch Later', {
                             clickTrackingParams: null,
                             playlistEditEndpoint: {
                                 playlistId: 'WL',
-                                actions: [
-                                    {
-                                        addedVideoId: data.videoId,
-                                        action: 'ACTION_ADD_VIDEO'
-                                    }
-                                ]
+                                actions: [watchLaterAction]
                             }
                         }),
                         MenuNavigationItemRenderer('Save to Playlist', {


### PR DESCRIPTION
- Fixes missing long-press menus in Watch Later.
- Watch Later items now correctly show and execute “Remove from Watch Later” instead of “Save to Watch Later”.