### PR TITLE
fix(standalone): recover from failed debug launch instead of hanging on splash

### DIFF
--- a/standalone/index.html
+++ b/standalone/index.html
@@ -76,10 +76,17 @@
             fetch('http://localhost:8100/tizentube/getState')
                 .then(r => r.json())
                 .then(res => {
+                    const proxyUrl = `http://localhost:8100/tv?additionalDataUrl=http%3A%2F%2Flocalhost%3A8100%2Fdial%2Fapps%2FYouTube${args ? `&${args}` : ''}`;
                     if (res.canConnectToDaemon && !res.isConnecting) {
                         fetch(`http://localhost:8100/tizentube/debugger${args ? `?${args}` : ''}`);
                         tizen.application.getCurrentApplication().exit();
-                    } else if (!res.canConnectToDaemon) location.href = `http://localhost:8100/tv?additionalDataUrl=http%3A%2F%2Flocalhost%3A8100%2Fdial%2Fapps%2FYouTube${args ? `&${args}` : ''}`
+                    } else {
+                        // Covers both !canConnectToDaemon and the previously unhandled
+                        // (canConnectToDaemon && isConnecting) state, which left the app
+                        // stuck on the splash screen forever. The proxy path injects the
+                        // userscript itself and needs no debugger.
+                        location.href = proxyUrl;
+                    }
                 }).catch(() => window.location.reload());
         }
 

--- a/standalone/service/utils/injector.js
+++ b/standalone/service/utils/injector.js
@@ -6,6 +6,16 @@ const fetch = require('node-fetch');
 
 
 var isConnecting = false;
+// `0 debug` only succeeds when the app is NOT already running. The app exits
+// just before we get here, but getAppsContext() reports it gone before Tizen has
+// finished tearing the process down, so the first attempt often returns nothing.
+const DEBUG_LAUNCH_RETRIES = 8;
+const DEBUG_LAUNCH_RETRY_MS = 400;
+// getAppsContext() reports the app gone before Tizen has finished tearing the
+// process down, so an immediate `0 debug` almost always lands too early. A short
+// head start lets the first attempt succeed on most TVs; the retries above
+// remain the safety net for slower ones.
+const DEBUG_LAUNCH_INITIAL_DELAY_MS = 500;
 const isTizen3 = tizen.systeminfo.getCapability('http://tizen.org/feature/platform.version').startsWith('3.0');
 
 function connectToDebugger(host, port, args) {
@@ -41,25 +51,55 @@ function canConnectToDaemon() {
         });
 }
 
+function attemptDebugLaunch(ip, args, attempt) {
+    const client = adbhost.createConnection({ host: '127.0.0.1', port: 26101 });
+
+    client._stream.on('connect', () => {
+        const packageId = tizen.application.getAppInfo().packageId;
+        let gotDebugPort = false;
+        const shellCmd = client.createStream(`shell:0 debug ${packageId}.TizenTubeStandalone${isTizen3 ? ' 0' : ''}`);
+
+        shellCmd.on('data', (data) => {
+            const dataString = data.toString();
+            if (dataString.includes('debug')) {
+                gotDebugPort = true;
+                const port = Number(dataString.substr(dataString.indexOf(':') + 1, 6).replace(' ', ''));
+                connectToDebugger(ip, port, args);
+                setTimeout(() => client._stream.end(), 1000);
+            }
+        });
+
+        // `0 debug` returns NOTHING (not an error) when the app is still running,
+        // so silence means "too early" -- retry rather than give up. Without this,
+        // isConnecting stays true for the lifetime of the service and every later
+        // launch dead-ends on the splash screen until the TV is restarted.
+        setTimeout(() => {
+            if (gotDebugPort) return;
+            try {
+                client._stream.end();
+            } catch (e) {
+                // Stream may already be gone; nothing to do.
+            }
+            if (attempt < DEBUG_LAUNCH_RETRIES) {
+                attemptDebugLaunch(ip, args, attempt + 1);
+            } else {
+                // Out of retries: clear the flag so the app falls back to the proxy
+                // path on its next launch instead of hanging forever.
+                isConnecting = false;
+            }
+        }, DEBUG_LAUNCH_RETRY_MS);
+    });
+
+    client._stream.on('error', () => {
+        if (attempt >= DEBUG_LAUNCH_RETRIES) isConnecting = false;
+    });
+}
+
 function startDebugger(args) {
     return canConnectToDaemon().then(res => {
         if (!res.canConnectToDaemon) return false;
-        const client = adbhost.createConnection({ host: '127.0.0.1', port: 26101 });
-
-        client._stream.on('connect', () => {
-            const packageId = tizen.application.getAppInfo().packageId;
-            isConnecting = true;
-            const shellCmd = client.createStream(`shell:0 debug ${packageId}.TizenTubeStandalone${isTizen3 ? ' 0' : ''}`);
-            shellCmd.on('data', (data) => {
-                const dataString = data.toString();
-                if (dataString.includes('debug')) {
-                    const port = Number(dataString.substr(dataString.indexOf(':') + 1, 6).replace(' ', ''));
-                    connectToDebugger(res.ip, port, args);
-                    setTimeout(() => client._stream.end(), 1000);
-                }
-            });
-        });
-
+        isConnecting = true;
+        setTimeout(() => attemptDebugLaunch(res.ip, args, 1), DEBUG_LAUNCH_INITIAL_DELAY_MS);
         return true;
     });
 }


### PR DESCRIPTION
I ran into this issue on my new 2025 S90F with TizenTube working but then when trying to wake it later it would be stuck on the loading screen. I (and Claude) dug into it further and found people had the same issue.

The short and sweet of it is it asks the TV for a debug port before the app has finished exiting, gets silence instead of an error, and never clears the "connecting" flag. Then you are stuck in the loading screen from the second launch on.

I've tested on my TV with Tizen 9 and it has held up across many many relaunches and force closes.
I am happy to try any changes you would rather make instead as I can turn it around quickly on my broken hardware.

AI writeup incoming:

 0 debug <appId> returns an empty reply rather than an error when the target app is still running — it launches an app in debug mode, it doesn't attach to a running one. The app exits just before the service calls it, but getAppsContext() reports it gone before Tizen has finished tearing the process down, so the call can land too early and return nothing.

Fixes #579.

## Problem

TizenTube Standalone loads on the first launch after install, then hangs on the splash screen with the progress bar spinning on every launch afterwards. Restarting the TV fixes it until the next time. Reported on Tizen 5.5, 8.0 and 9.0.

## Root cause

`0 debug <appId>` returns an **empty reply rather than an error** when the target app is still running — it launches an app in debug mode, it does not attach to a running one.

The app exits immediately before the service calls it, and `getAppsContext()` reports the app gone before Tizen has finished tearing the process down. When the call lands too early it returns nothing, and:

- the `shellCmd.on('data')` handler never fires, so `connectToDebugger()` is never reached
- `isConnecting` is only reset inside that callback, so it stays `true` for the lifetime of the service
- `useInjectorOrProxy()` has no branch for `(canConnectToDaemon && isConnecting)`, so every later launch falls through and does nothing

That last point is why the failure is permanent rather than intermittent, and why restarting the TV clears it — the service restarts and the flag resets.

## Verification

Measured on a Samsung TQ65S90FATXXC (2025 S90F, Tizen 9.0) over network sdb:

```
app running  ->  0 debug <appId>  ->  0 bytes
app stopped  ->  0 debug <appId>  ->  successfully launched pid = 14141 with debug 1 port: 45627
```

## Changes

- **`service/injector.js`** — retry the debug launch, since an empty reply means "too early" rather than "unsupported". Clear `isConnecting` once the retries are exhausted so the app can recover instead of wedging.
- **`index.html`** — `else if (!res.canConnectToDaemon)` becomes `else`, so the previously unhandled state falls back to the proxy path, which injects the userscript itself and needs no debugger.

## Testing

Patched build installed on the S90F with `developerIP = 127.0.0.1` — the configuration that previously hung on every relaunch. It now survives 5–6 back-out/reopen cycles and a full cold terminate, and ends up on the **debugger** path rather than the proxy fallback, so the preferred behaviour is preserved rather than silently degraded.

---

**Updated after review:** the retry now keys on the shell stream finishing rather than a fixed timeout (so a slow-but-valid `0 debug` on older TVs isn't aborted), all failure paths clear the connecting flag, exhaustion falls back to the proxy with a 5-minute retry TTL, and the `(canConnectToDaemon && isConnecting)` state is treated as a bounded wait (the debug-launched instance the service navigates via CDP) rather than an immediate proxy jump. One known limitation, left for a separate change: after the debugger path exhausts its retries the initiating instance has already exited, so that launch closes — the next launch recovers via the proxy.